### PR TITLE
Role management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 config.json
+dozer.db

--- a/dozer/__main__.py
+++ b/dozer/__main__.py
@@ -1,4 +1,5 @@
 import json, os.path, sys
+from . import db
 
 config = {'prefix': '&', 'developers': []}
 config_file = 'config.json'
@@ -23,5 +24,7 @@ bot = Dozer(config)
 for ext in os.listdir('dozer/cogs'):
 	if not ext.startswith('_'):
 		bot.load_extension('dozer.cogs.' + ext[:-3]) # Remove '.py'
+
+db.DatabaseObject.metadata.create_all()
 
 bot.run()

--- a/dozer/bot.py
+++ b/dozer/bot.py
@@ -13,11 +13,17 @@ class Dozer(commands.Bot):
 	
 	async def on_command_error(self, ctx, err):
 		if isinstance(err, commands.NoPrivateMessage):
-			await ctx.send('%s, This command cannot be used in DMs.' % ctx.author.mention)
+			await ctx.send('{}, This command cannot be used in DMs.'.format(ctx.author.mention))
 		elif isinstance(err, commands.UserInputError):
-			await ctx.send('%s, %s' % (ctx.author.mention, self.format_error(ctx, err)))
+			await ctx.send('{}, {}'.format(ctx.author.mention, self.format_error(ctx, err)))
 		elif isinstance(err, commands.NotOwner):
-			await ctx.send('%s, %s' % (ctx.author.mention, err.args[0]))
+			await ctx.send('{}, {}'.format(ctx.author.mention, err.args[0]))
+		elif isinstance(err, commands.MissingPermissions):
+			permission_names = [name.replace('guild', 'server').replace('_', ' ').title() for name in err.missing_perms]
+			await ctx.send('{}, you need {} permissions to run this command!'.format(ctx.author.mention, utils.pretty_concat(permission_names)))
+		elif isinstance(err, commands.BotMissingPermissions):
+			permission_names = [name.replace('guild', 'server').replace('_', ' ').title() for name in err.missing_perms]
+			await ctx.send('{}, I need {} permissions to run this command!'.format(ctx.author.mention, utils.pretty_concat(permission_names)))
 		else:
 			await ctx.send('```\n%s\n```' % ''.join(traceback.format_exception_only(type(err), err)).strip())
 			if isinstance(ctx.channel, discord.TextChannel):

--- a/dozer/cogs/roles.py
+++ b/dozer/cogs/roles.py
@@ -7,12 +7,12 @@ class Roles(Cog):
 	@group(invoke_without_command=True)
 	@bot_has_permissions(manage_roles=True)
 	async def giveme(self, ctx, *, roles):
-		"""Give you one or more givable roles, separated by commas."""
+		"""Give you one or more giveable roles, separated by commas."""
 		requests = set(name.strip().casefold() for name in roles.split(','))
-		givables = self.givable_roles(ctx.guild)
+		giveables = self.giveable_roles(ctx.guild)
 		
-		already_have = set(role for name, role in givables.items() if name in requests and role in ctx.author.roles)
-		valid = set(role for name, role in givables.items() if name in requests and role not in already_have)
+		already_have = set(role for name, role in giveables.items() if name in requests and role in ctx.author.roles)
+		valid = set(role for name, role in giveables.items() if name in requests and role not in already_have)
 		
 		await ctx.author.add_roles(*valid)
 		
@@ -23,60 +23,60 @@ class Roles(Cog):
 			e.add_field(name='You already have {} role(s)!'.format(len(already_have)), value='\n'.join(role.name for role in already_have), inline=False)
 		extra = len(requests) - (len(already_have) + len(valid))
 		if extra > 0:
-			e.add_field(name='{} role(s) could not be found!'.format(extra), value='Use `{0.prefix}{0.invoked_with} list` to find valid givable roles!'.format(ctx), inline=False)
+			e.add_field(name='{} role(s) could not be found!'.format(extra), value='Use `{0.prefix}{0.invoked_with} list` to find valid giveable roles!'.format(ctx), inline=False)
 		await ctx.send(embed=e)
 	
 	@giveme.command()
 	@bot_has_permissions(manage_roles=True)
 	@has_permissions(manage_guild=True)
 	async def add(self, ctx, *, name):
-		"""Makes an existing role givable, or creates one if it doesn't exist. Name must not contain commas.
+		"""Makes an existing role giveable, or creates one if it doesn't exist. Name must not contain commas.
 		Similar to create, but will use an existing role if one exists."""
 		if ',' in name:
-			raise BadArgument('givable role names must not contain commas!')
+			raise BadArgument('giveable role names must not contain commas!')
 		role = discord.utils.get(ctx.guild.roles, name=name)
 		if role is None:
-			role = await ctx.guild.create_role(name=name, reason='Givable role created by {}'.format(ctx.author))
-		elif name.strip().casefold() in self.givable_roles(ctx.guild):
-			raise BadArgument('that role already exists and is givable!')
+			role = await ctx.guild.create_role(name=name, reason='Giveable role created by {}'.format(ctx.author))
+		elif name.strip().casefold() in self.giveable_roles(ctx.guild):
+			raise BadArgument('that role already exists and is giveable!')
 		with db.Session() as session:
-			givables = session.query(GivableRoles).filter_by(guild_id=ctx.guild.id).first()
-			if givables is None:
-				givables = GivableRoles(guild_id=ctx.guild.id, role_ids=str(role.id))
-				session.add(givables)
+			giveables = session.query(GiveableRoles).filter_by(guild_id=ctx.guild.id).first()
+			if giveables is None:
+				giveables = GiveableRoles(guild_id=ctx.guild.id, role_ids=str(role.id))
+				session.add(giveables)
 			else:
-				givables.role_ids += ' ' + str(role.id)
-		await ctx.send('Added givable role {0.name!r}! Use `{1}{2} {0}` to get it!'.format(role, ctx.prefix, ctx.command.parent))
+				giveables.role_ids += ' ' + str(role.id)
+		await ctx.send('Added giveable role {0.name!r}! Use `{1}{2} {0}` to get it!'.format(role, ctx.prefix, ctx.command.parent))
 	
 	@giveme.command()
 	@bot_has_permissions(manage_roles=True)
 	@has_permissions(manage_guild=True)
 	async def create(self, ctx, *, name):
-		"""Create a givable role. Name must not contain commas.
+		"""Create a giveable role. Name must not contain commas.
 		Similar to add, but will always create a new role."""
 		if ',' in name:
-			raise BadArgument('givable role names must not contain commas!')
-		if name.strip().casefold() in self.givable_roles(ctx.guild):
-			raise BadArgument('a duplicate role is givable and would conflict!')
-		role = await ctx.guild.create_role(name=name, reason='Givable role created by {}'.format(ctx.author))
+			raise BadArgument('giveable role names must not contain commas!')
+		if name.strip().casefold() in self.giveable_roles(ctx.guild):
+			raise BadArgument('a duplicate role is giveable and would conflict!')
+		role = await ctx.guild.create_role(name=name, reason='Giveable role created by {}'.format(ctx.author))
 		with db.Session() as session:
-			givables = session.query(GivableRoles).filter_by(guild_id=ctx.guild.id).first()
-			if givables is None:
-				givables = GivableRoles(guild_id=ctx.guild.id, role_ids=str(role.id))
-				session.add(givables)
+			giveables = session.query(GiveableRoles).filter_by(guild_id=ctx.guild.id).first()
+			if giveables is None:
+				giveables = GiveableRoles(guild_id=ctx.guild.id, role_ids=str(role.id))
+				session.add(giveables)
 			else:
-				givables.role_ids += ' ' + str(role.id)
-		await ctx.send('Created givable role {0.name!r}! Use `{1}{2} {0}` to get it!'.format(role, ctx.prefix, ctx.command.parent))
+				giveables.role_ids += ' ' + str(role.id)
+		await ctx.send('Created giveable role {0.name!r}! Use `{1}{2} {0}` to get it!'.format(role, ctx.prefix, ctx.command.parent))
 	
 	@giveme.command()
 	@bot_has_permissions(manage_roles=True)
 	async def remove(self, ctx, *, roles):
-		"""Removes multiple givable roles from you. Names must be separated by commas."""
+		"""Removes multiple giveable roles from you. Names must be separated by commas."""
 		requests = set(name.strip().casefold() for name in roles.split(','))
-		givables = self.givable_roles(ctx.guild)
+		giveables = self.giveable_roles(ctx.guild)
 		
-		valid = set(role for name, role in givables.items() if name in requests and role in ctx.author.roles)
-		dont_have = set(role for name, role in givables.items() if name in requests and role not in valid)
+		valid = set(role for name, role in giveables.items() if name in requests and role in ctx.author.roles)
+		dont_have = set(role for name, role in giveables.items() if name in requests and role not in valid)
 		
 		await ctx.author.remove_roles(*valid)
 		
@@ -87,36 +87,44 @@ class Roles(Cog):
 			e.add_field(name='You didn\'t have {} role(s)!'.format(len(dont_have)), value='\n'.join(role.name for role in dont_have), inline=False)
 		extra = len(requests) - (len(valid) + len(dont_have))
 		if extra > 0:
-			e.add_field(name='{} role(s) could not be found!'.format(extra), value='Use `{0.prefix}{0.command.parent} list` to find valid givable roles!'.format(ctx), inline=False)
+			e.add_field(name='{} role(s) could not be found!'.format(extra), value='Use `{0.prefix}{0.command.parent} list` to find valid giveable roles!'.format(ctx), inline=False)
 		await ctx.send(embed=e)
 	
 	@giveme.command()
 	@bot_has_permissions(manage_roles=True)
 	@has_permissions(manage_guild=True)
 	async def delete(self, ctx, *, name):
-		"""Deletes and removes a givable role."""
-		roles = self.givable_roles(ctx.guild)
+		"""Deletes and removes a giveable role."""
+		roles = self.giveable_roles(ctx.guild)
 		stripped = name.casefold().strip()
 		if stripped not in roles:
-			raise BadArgument('{} is not a givable role!'.format(name))
+			raise BadArgument('{} is not a giveable role!'.format(name))
 		role = roles[stripped]
 		await role.delete()
 		with db.Session() as session:
-			givables = session.query(GivableRoles).filter_by(guild_id=ctx.guild.id).first() # Null-checked by givables containing name
-			givables.role_ids = givables.role_ids.replace(str(role), '').replace('  ', ' ').strip()
+			giveables = session.query(GiveableRoles).filter_by(guild_id=ctx.guild.id).first() # Null-checked by giveables containing name
+			giveables.role_ids = giveables.role_ids.replace(str(role.id), '').replace('  ', ' ').strip()
 		await ctx.send('Role {0.name!r} has been deleted!'.format(role))
 	
+	@giveme.command(name='list')
+	@bot_has_permissions(manage_roles=True)
+	async def list_roles(self, ctx):
+		roles = self.giveable_roles(ctx.guild)
+		e = discord.Embed(color=discord.Color.blue(), title='Giveable roles')
+		e.description = '\n'.join(role.name for role in roles.values())
+		await ctx.send(embed=e)
+	
 	@staticmethod
-	def givable_roles(guild):
+	def giveable_roles(guild):
 		with db.Session() as session:
-			roles = session.query(GivableRoles).filter_by(guild_id=guild.id).first()
+			roles = session.query(GiveableRoles).filter_by(guild_id=guild.id).first()
 		if roles is None:
 			return {}
-		givable_ids = [int(id_) for id_ in roles.role_ids.split(' ')]
-		return {role.name.strip().casefold(): role for role in guild.roles if role.id in givable_ids}
+		giveable_ids = [int(id_) for id_ in roles.role_ids.split(' ')]
+		return {role.name.strip().casefold(): role for role in guild.roles if role.id in giveable_ids}
 
-class GivableRoles(db.DatabaseObject):
-	__tablename__ = 'givable_roles'
+class GiveableRoles(db.DatabaseObject):
+	__tablename__ = 'giveable_roles'
 	guild_id = db.Column(db.Integer, primary_key=True)
 	role_ids = db.Column(db.String, nullable=True)
 

--- a/dozer/cogs/roles.py
+++ b/dozer/cogs/roles.py
@@ -1,4 +1,4 @@
-import discord
+import discord, discord.utils
 from discord.ext.commands import bot_has_permissions, has_permissions, BadArgument
 from .. import db
 from ._utils import *
@@ -7,24 +7,7 @@ class Roles(Cog):
 	@group(invoke_without_command=True)
 	@bot_has_permissions(manage_roles=True)
 	async def giveme(self, ctx, *, roles):
-		"""Give you one or more giveable roles, separated by commas."""
-		requests = set(name.strip().casefold() for name in roles.split(','))
-		giveables = self.giveable_roles(ctx.guild)
-		
-		already_have = set(role for name, role in giveables.items() if name in requests and role in ctx.author.roles)
-		valid = set(role for name, role in giveables.items() if name in requests and role not in already_have)
-		
-		await ctx.author.add_roles(*valid)
-		
-		e = discord.Embed(color=discord.Color.blue())
-		if valid:
-			e.add_field(name='Gave you {} role(s)!'.format(len(valid)), value='\n'.join(role.name for role in valid), inline=False)
-		if already_have:
-			e.add_field(name='You already have {} role(s)!'.format(len(already_have)), value='\n'.join(role.name for role in already_have), inline=False)
-		extra = len(requests) - (len(already_have) + len(valid))
-		if extra > 0:
-			e.add_field(name='{} role(s) could not be found!'.format(extra), value='Use `{0.prefix}{0.invoked_with} list` to find valid giveable roles!'.format(ctx), inline=False)
-		await ctx.send(embed=e)
+		"""[DISABLED] Give you one or more giveable roles, separated by commas."""
 	
 	@giveme.command()
 	@bot_has_permissions(manage_roles=True)
@@ -34,99 +17,70 @@ class Roles(Cog):
 		Similar to create, but will use an existing role if one exists."""
 		if ',' in name:
 			raise BadArgument('giveable role names must not contain commas!')
-		role = discord.utils.get(ctx.guild.roles, name=name)
-		if role is None:
-			role = await ctx.guild.create_role(name=name, reason='Giveable role created by {}'.format(ctx.author))
-		elif name.strip().casefold() in self.giveable_roles(ctx.guild):
-			raise BadArgument('that role already exists and is giveable!')
+		norm_name = self.normalize(name)
 		with db.Session() as session:
-			giveables = session.query(GiveableRoles).filter_by(guild_id=ctx.guild.id).first()
-			if giveables is None:
-				giveables = GiveableRoles(guild_id=ctx.guild.id, role_ids=str(role.id))
-				session.add(giveables)
+			settings = session.query(GuildSettings).one_or_none()
+			if settings is None:
+				settings = GuildSettings(id=ctx.guild.id)
+				session.add(settings)
+			if norm_name in (giveable.norm_name for giveable in settings.giveable_roles):
+				raise BadArgument('that role already exists and is giveable!')
+			candidates = [role for role in ctx.guild.roles if self.normalize(role.name) == norm_name]
+			
+			if not candidates:
+				role = await ctx.guild.create_role(name=name, reason='Giveable role created by {}'.format(ctx.author))
+			elif len(candidates) == 1:
+				role = candidates[0]
 			else:
-				giveables.role_ids += ' ' + str(role.id)
-		await ctx.send('Added giveable role {0.name!r}! Use `{1}{2} {0}` to get it!'.format(role, ctx.prefix, ctx.command.parent))
+				raise BadArgument('{} roles with that name exist!'.format(len(candidates)))
+			settings.giveable_roles.append(GiveableRole.from_role(role))
+		await ctx.send('Role "{0}" added! Use `{1}{2} {0}` to get it!'.format(role.name, ctx.prefix, ctx.command.parent))
 	
 	@giveme.command()
 	@bot_has_permissions(manage_roles=True)
 	@has_permissions(manage_guild=True)
 	async def create(self, ctx, *, name):
-		"""Create a giveable role. Name must not contain commas.
+		"""[DISABLED] Create a giveable role. Name must not contain commas.
 		Similar to add, but will always create a new role."""
-		if ',' in name:
-			raise BadArgument('giveable role names must not contain commas!')
-		if name.strip().casefold() in self.giveable_roles(ctx.guild):
-			raise BadArgument('a duplicate role is giveable and would conflict!')
-		role = await ctx.guild.create_role(name=name, reason='Giveable role created by {}'.format(ctx.author))
-		with db.Session() as session:
-			giveables = session.query(GiveableRoles).filter_by(guild_id=ctx.guild.id).first()
-			if giveables is None:
-				giveables = GiveableRoles(guild_id=ctx.guild.id, role_ids=str(role.id))
-				session.add(giveables)
-			else:
-				giveables.role_ids += ' ' + str(role.id)
-		await ctx.send('Created giveable role {0.name!r}! Use `{1}{2} {0}` to get it!'.format(role, ctx.prefix, ctx.command.parent))
 	
 	@giveme.command()
 	@bot_has_permissions(manage_roles=True)
 	async def remove(self, ctx, *, roles):
-		"""Removes multiple giveable roles from you. Names must be separated by commas."""
-		requests = set(name.strip().casefold() for name in roles.split(','))
-		giveables = self.giveable_roles(ctx.guild)
-		
-		valid = set(role for name, role in giveables.items() if name in requests and role in ctx.author.roles)
-		dont_have = set(role for name, role in giveables.items() if name in requests and role not in valid)
-		
-		await ctx.author.remove_roles(*valid)
-		
-		e = discord.Embed(color=discord.Color.blue())
-		if valid:
-			e.add_field(name='Removed {} role(s)!'.format(len(valid)), value='\n'.join(role.name for role in valid), inline=False)
-		if dont_have:
-			e.add_field(name='You didn\'t have {} role(s)!'.format(len(dont_have)), value='\n'.join(role.name for role in dont_have), inline=False)
-		extra = len(requests) - (len(valid) + len(dont_have))
-		if extra > 0:
-			e.add_field(name='{} role(s) could not be found!'.format(extra), value='Use `{0.prefix}{0.command.parent} list` to find valid giveable roles!'.format(ctx), inline=False)
-		await ctx.send(embed=e)
+		"""[DISABLED] Removes multiple giveable roles from you. Names must be separated by commas."""
 	
 	@giveme.command()
 	@bot_has_permissions(manage_roles=True)
 	@has_permissions(manage_guild=True)
 	async def delete(self, ctx, *, name):
-		"""Deletes and removes a giveable role."""
-		roles = self.giveable_roles(ctx.guild)
-		stripped = name.casefold().strip()
-		if stripped not in roles:
-			raise BadArgument('{} is not a giveable role!'.format(name))
-		role = roles[stripped]
-		await role.delete()
-		with db.Session() as session:
-			giveables = session.query(GiveableRoles).filter_by(guild_id=ctx.guild.id).first() # Null-checked by giveables containing name
-			giveables.role_ids = giveables.role_ids.replace(str(role.id), '').replace('  ', ' ').strip()
-		await ctx.send('Role {0.name!r} has been deleted!'.format(role))
+		"""[DISABLED] Deletes and removes a giveable role."""
 	
 	@giveme.command(name='list')
 	@bot_has_permissions(manage_roles=True)
 	async def list_roles(self, ctx):
-		roles = self.giveable_roles(ctx.guild)
-		e = discord.Embed(color=discord.Color.blue(), title='Giveable roles')
-		e.description = '\n'.join(role.name for role in roles.values())
-		await ctx.send(embed=e)
+		"""[DISABLED] Lists all giveable roles for this server."""
 	
 	@staticmethod
-	def giveable_roles(guild):
-		with db.Session() as session:
-			roles = session.query(GiveableRoles).filter_by(guild_id=guild.id).first()
-		if roles is None:
-			return {}
-		giveable_ids = [int(id_) for id_ in roles.role_ids.split(' ')]
-		return {role.name.strip().casefold(): role for role in guild.roles if role.id in giveable_ids}
+	def normalize(name):
+		return name.strip().casefold()
 
-class GiveableRoles(db.DatabaseObject):
+class GuildSettings(db.DatabaseObject):
+	__tablename__ = 'guilds'
+	id = db.Column(db.Integer, primary_key=True)
+
+class GiveableRole(db.DatabaseObject):
 	__tablename__ = 'giveable_roles'
-	guild_id = db.Column(db.Integer, primary_key=True)
-	role_ids = db.Column(db.String, nullable=True)
+	id = db.Column(db.Integer, primary_key=True)
+	name = db.Column(db.String(100), nullable=False)
+	norm_name = db.Column(db.String(100), nullable=False)
+	guild_id = db.Column(db.Integer, db.ForeignKey('guilds.id'))
+	guild_settings = db.relationship('GuildSettings', back_populates='giveable_roles')
+	
+	@classmethod
+	def from_role(cls, role):
+		"""Creates a GiveableRole record from a discord.Role."""
+		return cls(id=role.id, name=role.name, norm_name=Roles.normalize(role.name))
+
+GuildSettings.giveable_roles = db.relationship('GiveableRole', order_by=GiveableRole.id, back_populates='guild_settings')
 
 def setup(bot):
 	bot.add_cog(Roles(bot))

--- a/dozer/cogs/roles.py
+++ b/dozer/cogs/roles.py
@@ -1,5 +1,5 @@
 import discord
-from discord.ext.commands import bot_has_permissions, BadArgument
+from discord.ext.commands import bot_has_permissions, has_permissions, BadArgument
 from .. import db
 from ._utils import *
 
@@ -28,6 +28,7 @@ class Roles(Cog):
 	
 	@giveme.command()
 	@bot_has_permissions(manage_roles=True)
+	@has_permissions(manage_guild=True)
 	async def add(self, ctx, *, name):
 		"""Makes an existing role givable, or creates one if it doesn't exist. Name must not contain commas.
 		Similar to create, but will use an existing role if one exists."""
@@ -49,6 +50,7 @@ class Roles(Cog):
 	
 	@giveme.command()
 	@bot_has_permissions(manage_roles=True)
+	@has_permissions(manage_guild=True)
 	async def create(self, ctx, *, name):
 		"""Create a givable role. Name must not contain commas.
 		Similar to add, but will always create a new role."""

--- a/dozer/cogs/roles.py
+++ b/dozer/cogs/roles.py
@@ -1,0 +1,44 @@
+import discord
+from discord.ext.commands import bot_has_permissions
+from .. import db
+from ._utils import *
+
+class Roles(Cog):
+	@group(invoke_without_command=True)
+	@bot_has_permissions(manage_roles=True)
+	async def giveme(self, ctx):
+		"""Give you one or more givable roles, separated by commas."""
+		requests = set(name.strip().casefold() for name in roles.split(','))
+		givables = self.givable_roles(ctx.guild)
+		
+		already_have = set(role for name, role in givables.items() if name in requests and role in ctx.author.roles)
+		valid = set(role for name, role in givables.items() if name in requests and role not in already_have)
+		
+		await ctx.author.add_roles(*valid)
+		
+		e = discord.Embed(color=discord.Color.blue())
+		if valid:
+			e.add_field(name='Gave you {} role(s)!'.format(len(valid)), value='\n'.join(role.name for role in valid), inline=False)
+		if already_have:
+			e.add_field(name='You already have {} role(s)!'.format(len(already_have)), value='\n'.join(role.name for role in already_have), inline=False)
+		extra = len(requests) - (len(already_have) + len(valid))
+		if extra > 0:
+			e.add_field(name='{} role(s) could not be found!'.format(extra), value='Use `{0.prefix}{0.invoked_with} list` to find valid givable roles!'.format(ctx), inline=False)
+		await ctx.send(embed=e)
+	
+	@staticmethod
+	def givable_roles(guild):
+		with db.Session() as session:
+			roles = session.query(GivableRoles).filter_by(guild_id=guild.id).first()
+		if roles is None:
+			return {}
+		givable_ids = [int(id_) for id_ in roles.role_ids.split(' ')]
+		return {role.name.strip().casefold(): role for role in guild.roles if role.id in givable_ids}
+
+class GivableRoles(db.DatabaseObject):
+	__tablename__ = 'givable_roles'
+	guild_id = db.Column(db.Integer, primary_key=True)
+	role_ids = db.Column(db.String, nullable=True)
+
+def setup(bot):
+	bot.add_cog(Roles(bot))

--- a/dozer/cogs/roles.py
+++ b/dozer/cogs/roles.py
@@ -1,12 +1,12 @@
 import discord
-from discord.ext.commands import bot_has_permissions
+from discord.ext.commands import bot_has_permissions, BadArgument
 from .. import db
 from ._utils import *
 
 class Roles(Cog):
 	@group(invoke_without_command=True)
 	@bot_has_permissions(manage_roles=True)
-	async def giveme(self, ctx):
+	async def giveme(self, ctx, *, roles):
 		"""Give you one or more givable roles, separated by commas."""
 		requests = set(name.strip().casefold() for name in roles.split(','))
 		givables = self.givable_roles(ctx.guild)
@@ -25,6 +25,46 @@ class Roles(Cog):
 		if extra > 0:
 			e.add_field(name='{} role(s) could not be found!'.format(extra), value='Use `{0.prefix}{0.invoked_with} list` to find valid givable roles!'.format(ctx), inline=False)
 		await ctx.send(embed=e)
+	
+	@giveme.command()
+	@bot_has_permissions(manage_roles=True)
+	async def add(self, ctx, *, name):
+		"""Makes an existing role givable, or creates one if it doesn't exist. Name must not contain commas.
+		Similar to create, but will use an existing role if one exists."""
+		if ',' in name:
+			raise BadArgument('givable role names must not contain commas!')
+		role = discord.utils.get(ctx.guild.roles, name=name)
+		if role is None:
+			role = await ctx.guild.create_role(name=name, reason='Givable role created by {}'.format(ctx.author))
+		elif name.strip().casefold() in self.givable_roles(ctx.guild):
+			raise BadArgument('that role already exists and is givable!')
+		with db.Session() as session:
+			givables = session.query(GivableRoles).filter_by(guild_id=ctx.guild.id).first()
+			if givables is None:
+				givables = GivableRoles(guild_id=ctx.guild.id, role_ids=str(role.id))
+				session.add(givables)
+			else:
+				givables.role_ids += ' ' + str(role.id)
+		await ctx.send('Created givable role {0}! Use `{1}{2} {0}` to get it!'.format(role, ctx.prefix, ctx.command.parent))
+	
+	@giveme.command()
+	@bot_has_permissions(manage_roles=True)
+	async def create(self, ctx, *, name):
+		"""Create a givable role. Name must not contain commas.
+		Similar to add, but will always create a new role."""
+		if ',' in name:
+			raise BadArgument('givable role names must not contain commas!')
+		if name.strip().casefold() in self.givable_roles(ctx.guild):
+			raise BadArgument('a duplicate role is givable and would conflict!')
+		role = await ctx.guild.create_role(name=name, reason='Givable role created by {}'.format(ctx.author))
+		with db.Session() as session:
+			givables = session.query(GivableRoles).filter_by(guild_id=ctx.guild.id).first()
+			if givables is None:
+				givables = GivableRoles(guild_id=ctx.guild.id, role_ids=str(role.id))
+				session.add(givables)
+			else:
+				givables.role_ids += ' ' + str(role.id)
+		await ctx.send('Created givable role {0}! Use `{1}{2} {0}` to get it!'.format(role, ctx.prefix, ctx.command.parent))
 	
 	@staticmethod
 	def givable_roles(guild):

--- a/dozer/cogs/roles.py
+++ b/dozer/cogs/roles.py
@@ -40,7 +40,7 @@ class Roles(Cog):
 			raise BadArgument('giveable role names must not contain commas!')
 		norm_name = self.normalize(name)
 		with db.Session() as session:
-			settings = session.query(GuildSettings).one_or_none()
+			settings = session.query(GuildSettings).filter_by(id=ctx.guild.id).one_or_none()
 			if settings is None:
 				settings = GuildSettings(id=ctx.guild.id)
 				session.add(settings)
@@ -67,7 +67,7 @@ class Roles(Cog):
 			raise BadArgument('giveable role names must not contain commas!')
 		norm_name = self.normalize(name)
 		with db.Session() as session:
-			settings = session.query(GuildSettings).one_or_none()
+			settings = session.query(GuildSettings).filter_by(id=ctx.guild.id).one_or_none()
 			if settings is None:
 				settings = GuildSettings(id=ctx.guild.id)
 				session.add(settings)

--- a/dozer/cogs/roles.py
+++ b/dozer/cogs/roles.py
@@ -139,6 +139,21 @@ class Roles(Cog):
 	@staticmethod
 	def normalize(name):
 		return name.strip().casefold()
+	
+	@command()
+	@bot_has_permissions(manage_roles=True)
+	@has_permissions(manage_roles=True)
+	async def give(self, ctx, member : discord.Member, *, role : discord.Role):
+		"""Gives a member a role. Not restricted to giveable roles."""
+		await member.add_roles(role)
+		await ctx.send('Successfully gave {} "{}"!'.format(member, role))
+	
+	@command()
+	@bot_has_permissions(manage_roles=True)
+	@has_permissions(manage_roles=True)
+	async def take(self, ctx, member : discord.Member, *, role : discord.Role):
+		await member.remove_roles(role)
+		await ctx.send('Successfully removed "{}" from {}!'.format(role, member))
 
 class GuildSettings(db.DatabaseObject):
 	__tablename__ = 'guilds'

--- a/dozer/db.py
+++ b/dozer/db.py
@@ -1,0 +1,22 @@
+import sqlalchemy
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import Session, sessionmaker
+
+__all__ = ['engine', 'DatabaseObject', 'Session', 'Column', 'Integer', 'String']
+
+engine = sqlalchemy.create_engine('sqlite:///dozer.db')
+DatabaseObject = declarative_base(bind=engine, name='DatabaseObject')
+
+class CtxSession(Session):
+	def __enter__(self):
+		return self
+	
+	def __exit__(self, err_type, err, tb):
+		if err_type is None:
+			self.commit()
+		else:
+			self.rollback()
+		return False
+
+Session = sessionmaker(bind=engine, class_=CtxSession)

--- a/dozer/db.py
+++ b/dozer/db.py
@@ -1,9 +1,9 @@
 import sqlalchemy
-from sqlalchemy import Column, Integer, String
+from sqlalchemy import Column, Integer, String, ForeignKey
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.orm import relationship, Session, sessionmaker
 
-__all__ = ['engine', 'DatabaseObject', 'Session', 'Column', 'Integer', 'String']
+__all__ = ['engine', 'DatabaseObject', 'Session', 'Column', 'Integer', 'String', 'ForeignKey', 'relationship']
 
 engine = sqlalchemy.create_engine('sqlite:///dozer.db')
 DatabaseObject = declarative_base(bind=engine, name='DatabaseObject')

--- a/dozer/utils.py
+++ b/dozer/utils.py
@@ -49,3 +49,11 @@ def clean_channel_name(ctx, channel_id):
 		return '#' + channel.name
 	else:
 		return '<#\N{ZERO WIDTH SPACE}%d>' % channel.id
+
+def pretty_concat(strings, single_suffix='', multi_suffix=''):
+	if len(strings) == 1:
+		return strings[0] + single_suffix
+	elif len(strings) == 2:
+		return '{} and {}{}'.format(*strings, multi_suffix)
+	else:
+		return '{}, and {}{}'.format(', '.join(strings[:-1]), strings[-1], multi_suffix)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 https://github.com/Rapptz/discord.py/archive/rewrite.zip#egg=discord.py
+sqlalchemy


### PR DESCRIPTION
- [x] `&giveme <rolename>[, <rolename>[, ...]]` gives you any number of roles in the giveme whitelist. Names are case-insensitive.
- [x] `&giveme add <rolename>` finds or creates a role named <rolename> and adds it to the giveme whitelist. Name is case-insensitive for existing role.
- [x] `&giveme create <rolename>` creates a role named <rolename> and adds it to the giveme whitelist.
- [x] `&giveme remove <rolename>[, <rolename>[, ...]]` removes any number of roles in the giveme whitelist from you. Names are case-insensitive.
- [x] `&giveme delete <rolename>` removes a role from the giveme whitelist and deletes it.
- [x] `&giveme list` lists all roles in the giveme whitelist.
- [x] `&give <member> <role>` gives <member> <role>. Members can be specified by username, username/discrim, nickname, ID, or mention, but are case-sensitive. Roles can be specified by name, ID or mention, but are case-sensitive.
- [x] `&take <member> <role>` removes <role> from <member>. Members can be specified by username, username/discrim, nickname, ID, or mention, but are case-sensitive. Roles can be specified by name, ID or mention, but are case-sensitive.

If you delete a giveable role through the role list rather than `&giveme delete`, its record will stay in the table but, it won't show up in `&giveme list` and will act like it's not there. Either 1) that's fine, 2) I add an event handler for when roles are deleted and delete the giveme record, or 3) I create `&giveme clean` that removes all IDs that don't exist at once. I'm impartial.