### PR TITLE
Restore roles on rejoin

### DIFF
--- a/dozer/cogs/roles.py
+++ b/dozer/cogs/roles.py
@@ -201,12 +201,11 @@ class MissingMember(db.DatabaseObject):
 class MissingRole(db.DatabaseObject):
 	__tablename__ = 'missing_roles'
 	__table_args__ = (db.ForeignKeyConstraint(['guild_id', 'member_id'], ['missing_members.guild_id', 'missing_members.member_id']),)
-	pk = db.Column(db.Integer, primary_key=True, autoincrement=True) # Composite of foreign primary keys (guild/member id) caused errors
-	role_id = db.Column(db.Integer)
-	guild_id = db.Column(db.Integer)
-	member_id = db.Column(db.Integer)
-	member = db.relationship('MissingMember', back_populates='missing_roles')
+	role_id = db.Column(db.Integer, primary_key=True)
+	guild_id = db.Column(db.Integer) # Guild ID doesn't have to be primary because role IDs are unique across guilds
+	member_id = db.Column(db.Integer, primary_key=True)
 	role_name = db.Column(db.String(100), nullable=False)
+	member = db.relationship('MissingMember', back_populates='missing_roles')
 
 MissingMember.missing_roles = db.relationship('MissingRole', back_populates='member')
 

--- a/dozer/db.py
+++ b/dozer/db.py
@@ -1,5 +1,5 @@
 import sqlalchemy
-from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy import Column, Integer, String, ForeignKey, ForeignKeyConstraint
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship, Session, sessionmaker
 


### PR DESCRIPTION
- [x] Save role name and ID to the database when a member leaves
- [x] Restore all valid saved roles on rejoin
- [x] Notify users of any roles that couldn't be restored

When members rejoin, roles are found by the ID recorded. If the role no longer exists, roles of the same/similar name are **not** used instead. Consider an "Admin" giveme role for essays/leadership being confused with "Admins" for server admins.

Should a role not exist, or should the bot not have permission to give it, a message is composed with all of the roles that were not restored. That message is sent to the first channel the bot can send in, falling back to the server owner's DMs. I'm open to suggestions on how to handle this - DMing the owner seems abusable, and with most servers set up so mod bots can talk in announcement/info channels this could put messages where they shouldn't be.