### PR TITLE
Rewritten help command

### DIFF
--- a/dozer/cogs/_utils.py
+++ b/dozer/cogs/_utils.py
@@ -18,7 +18,13 @@ class Command(commands.Command, CommandMixin):
 	pass
 
 class Group(commands.Group, CommandMixin):
-	pass
+	def command(self, **kwargs):
+		kwargs.setdefault('cls', Group)
+		return super(Group, self).command(**kwargs)
+	
+	def group(self, **kwargs):
+		kwargs.setdefault('cls', Group)
+		return super(Group, self).command(**kwargs)
 
 def command(**kwargs):
 	kwargs.setdefault('cls', Command)

--- a/dozer/cogs/_utils.py
+++ b/dozer/cogs/_utils.py
@@ -1,7 +1,141 @@
+import asyncio, itertools
 from discord.ext.commands import command, group
 
-__all__ = ['command', 'group', 'Cog']
+__all__ = ['command', 'group', 'Cog', 'Reactor', 'Paginator', 'paginate']
 
 class Cog:
 	def __init__(self, bot):
 		self.bot = bot
+
+class Reactor:
+	"""
+	A simple way to respond to Discord reactions.
+	Usage:
+		from ._utils import Reactor
+		# in a command
+		initial_reactions = [...] # Initial reactions (str or Emoji) to add
+		reactor = Reactor(ctx, initial_reactions) # Timeout is optional, and defaults to 1 minute
+		async for reaction in reactor:
+			# reaction is the str/Emoji that was added.
+			# reaction will not necessarily be in initial_reactions.
+			if reaction == this_emoji:
+				reactor.do(reactor.message.edit(content='This!')) # Any coroutine
+			elif reaction == that_emoji:
+				reactor.do(reactor.message.edit(content='That!'))
+			elif reaction == stop_emoji:
+				reactor.stop() # The next time around, the message will be deleted and the async-for will end
+			# If no action is set (e.g. unknown emoji), nothing happens
+	"""
+	_stop_reaction = object()
+	def __init__(self, ctx, initial_reactions, *, auto_remove=True, timeout=60):
+		"""
+		ctx: command context
+		initial_reactions: iterable of emoji to react with on start
+		auto_remove: if True, reactions are removed once processed
+		timeout: time, in seconds, to wait before stopping automatically. Set to None to wait forever.
+		"""
+		self.dest = ctx.channel
+		self.bot = ctx.bot
+		self.member = ctx.author
+		self._reactions = tuple(initial_reactions)
+		self._remove_reactions = auto_remove
+		self.timeout = timeout
+		self._action = None
+	
+	async def __aiter__(self):
+		self.message = await self.dest.send(embed=self.pages[self.page])
+		for emoji in self._reactions:
+			await self.message.add_reaction(emoji)
+		while True:
+			try:
+				reaction, reacting_member = await self.bot.wait_for('reaction_add', check=self._check_reaction, timeout=self.timeout)
+			except asyncio.TimeoutError:
+				break
+			
+			yield reaction.emoji
+			# Caller calls methods to set self._action; end of async for block, control resumes here
+			if self._remove_reactions:
+				await self.message.remove_reaction(reaction.emoji, reacting_member)
+			if self._action is self._stop_reaction:
+				break
+			elif self._action is None:
+				pass
+			else:
+				await self._action
+		await self.message.delete()
+	
+	def do(self, action):
+		self._action = action
+	
+	def stop(self):
+		self._action = self._stop_reaction
+	
+	def _check_reaction(self, reaction, member):
+		return reaction.message.id == self.message.id and member.id == self.member.id
+
+class Paginator(Reactor):
+	"""
+	Extends functionality of Reactor for pagination.
+	Left- and right- arrow reactions are used to move between pages.
+	:stop: will stop the pagination.
+	Other reactions are given to the caller like normal.
+	Usage:
+		from ._utils import Reactor
+		# in a command
+		initial_reactions = [...] # Initial reactions (str or Emoji) to add (in addition to normal pagination reactions)
+		pages = [...] # Embeds to use for each page
+		paginator = Paginator(ctx, initial_reactions, pages)
+		async for reaction in paginator:
+			# See Reactor for how to handle reactions
+			# Paginator reactions will not be yielded here - only unknowns
+	"""
+	pagination_reactions = (
+		'\N{BLACK LEFT-POINTING DOUBLE TRIANGLE WITH VERTICAL BAR}', # :track_previous:
+		'\N{BLACK LEFT-POINTING TRIANGLE}', # :arrow_backward:
+		'\N{BLACK RIGHT-POINTING TRIANGLE}', # :arrow_forward:
+		'\N{BLACK RIGHT-POINTING DOUBLE TRIANGLE WITH VERTICAL BAR}', # :track_next:
+		'\N{BLACK SQUARE FOR STOP}' # :stop_button:
+	)
+	def __init__(self, ctx, initial_reactions, pages, *, start=0, auto_remove=True, timeout=60):
+		super().__init__(ctx, itertools.chain(self.pagination_reactions + initial_reactions), auto_remove=auto_remove, timeout=timeout)
+		self.pages = pages
+		self.page = start
+	
+	async def __aiter__(self):
+		self.reactor = super().__aiter__()
+		async for reaction in self.reactor:
+			try:
+				ind = self.pagination_reactions.index(reaction)
+			except ValueError: # Not in list - send to caller
+				yield reaction
+			else:
+				if ind == 0:
+					self.go_to_page(0)
+				elif ind == 1:
+					self.prev()
+				elif ind == 2:
+					self.next()
+				elif ind == 3:
+					self.go_to_page(-1)
+				else: # Only valid option left is 4
+					self.stop()
+	
+	def go_to_page(self, page):
+		self.page = page % len(self.pages)
+		if self.page < 0:
+			self.page += len(self.pages)
+		self.do(self.message.edit(embed=self.pages[self.page]))
+	
+	def next(self, amt=1):
+		self.go_to_page(self.page + amt)
+	
+	def prev(self, amt=1):
+		self.go_to_page(self.page - amt)
+
+async def paginate(ctx, pages, *, start=0, auto_remove=True, timeout=60):
+	"""
+	Simple pagination based on Paginator. Pagination is handled normally and other reactions are ignored.
+	"""
+	paginator = Paginator(ctx, (), pages, start=start, auto_remove=auto_remove, timeout=timeout)
+	async for reaction in paginator:
+		pass # The normal pagination reactions are handled - just drop anything else

--- a/dozer/cogs/_utils.py
+++ b/dozer/cogs/_utils.py
@@ -36,7 +36,8 @@ class Reactor:
 		"""
 		self.dest = ctx.channel
 		self.bot = ctx.bot
-		self.member = ctx.author
+		self.caller = ctx.author
+		self.me = ctx.me
 		self._reactions = tuple(initial_reactions)
 		self._remove_reactions = auto_remove
 		self.timeout = timeout
@@ -62,7 +63,8 @@ class Reactor:
 				pass
 			else:
 				await self._action
-		await self.message.delete()
+		for emoji in reversed(self._reactions):
+			await self.message.remove_reaction(emoji, self.me)
 	
 	def do(self, action):
 		self._action = action
@@ -71,7 +73,7 @@ class Reactor:
 		self._action = self._stop_reaction
 	
 	def _check_reaction(self, reaction, member):
-		return reaction.message.id == self.message.id and member.id == self.member.id
+		return reaction.message.id == self.message.id and member.id == self.caller.id
 
 class Paginator(Reactor):
 	"""

--- a/dozer/cogs/_utils.py
+++ b/dozer/cogs/_utils.py
@@ -1,7 +1,7 @@
 import asyncio, itertools
 from discord.ext.commands import command, group
 
-__all__ = ['command', 'group', 'Cog', 'Reactor', 'Paginator', 'paginate']
+__all__ = ['command', 'group', 'Cog', 'Reactor', 'Paginator', 'paginate', 'chunk']
 
 class Cog:
 	def __init__(self, bot):
@@ -139,3 +139,13 @@ async def paginate(ctx, pages, *, start=0, auto_remove=True, timeout=60):
 	paginator = Paginator(ctx, (), pages, start=start, auto_remove=auto_remove, timeout=timeout)
 	async for reaction in paginator:
 		pass # The normal pagination reactions are handled - just drop anything else
+
+def chunk(iterable, size):
+	"""
+	Break an iterable into chunks of a fixed size. Returns an iterable of iterables.
+	Almost-inverse of itertools.chain.from_iterable - passing the output of this into that function will reconstruct the original iterable.
+	If the last chunk is not the full length, it will be returned but not padded.
+	"""
+	contents = list(iterable)
+	for i in range(0, len(contents), size):
+		yield contents[i:i+size]

--- a/dozer/cogs/development.py
+++ b/dozer/cogs/development.py
@@ -3,6 +3,10 @@ from discord.ext.commands import NotOwner
 from ._utils import *
 
 class Development(Cog):
+	"""
+	Commands useful for developing the bot.
+	These commands are restricted to bot developers.
+	"""
 	eval_globals = {}
 	for module in ('asyncio', 'collections', 'discord', 'inspect', 'itertools'):
 		eval_globals[module] = __import__(module)

--- a/dozer/cogs/development.py
+++ b/dozer/cogs/development.py
@@ -22,9 +22,16 @@ class Development(Cog):
 		self.bot.load_extension(extension)
 		await msg.edit(content='Reloaded extension %s' % extension)
 	
+	reload.example_usage = """
+	`{prefix}reload development` - reloads the development cog
+	"""
+	
 	@command(name='eval')
 	async def evaluate(self, ctx, *, code):
-		"""Evaluates Python. Await is valid and `{ctx}` is the command context."""
+		"""
+		Evaluates Python.
+		Await is valid and `{ctx}` is the command context.
+		"""
 		if code.startswith('```'): code = code.strip('```').partition('\n')[2].strip() # Remove multiline code blocks
 		else: code = code.strip('`').strip() # Remove single-line code blocks, if necessary
 		
@@ -44,6 +51,11 @@ class Development(Cog):
 			e.add_field(name='Error', value='```\n%s\n```' % repr(err))
 		await ctx.send(embed=e)
 	
+	evaluate.example_usage = """
+	`{prefix}eval 0.1 + 0.2` - calculates 0.1 + 0.2
+	`{prefix}eval await ctx.send('Hello world!')` - send "Hello World!" to this channel
+	"""
+	
 	@command(name='su', pass_context=True)
 	async def pseudo(self, ctx, user : discord.Member, *, command):
 		"""Execute a command as another user."""
@@ -52,6 +64,10 @@ class Development(Cog):
 		msg.content = command
 		context = await self.bot.get_context(msg)
 		return await self.bot.invoke(context)
+	
+	pseudo.example_usage = """
+	`{prefix}su cooldude#1234 {prefix}ping` - simulate cooldude sending `{prefix}ping`
+	"""
 
 def load_function(code, globals_, locals_):
 	function_header = 'async def evaluated_function(ctx):'

--- a/dozer/cogs/general.py
+++ b/dozer/cogs/general.py
@@ -16,7 +16,7 @@ class General(Cog):
 		await response.edit(content=response.content + '\nTook %d ms to respond.' % (delay.seconds * 1000 + delay.microseconds // 1000))
 	
 	ping.example_usage = """
-	`{prefix}{name}` - Calculate and display the bot's response time
+	`{prefix}ping` - Calculate and display the bot's response time
 	"""
 	
 	@command(name='help', aliases=['about'])
@@ -42,9 +42,9 @@ class General(Cog):
 				await self._help_command(ctx, command)
 	
 	base_help.example_usage = """
-	`{prefix}{name}` - General help message
-	`{prefix}{name} help` - Help about the help command
-	`{prefix}{name} General` - Help about the General category
+	`{prefix}help` - General help message
+	`{prefix}help help` - Help about the help command
+	`{prefix}help General` - Help about the General category
 	"""
 	
 	async def _help_all(self, ctx):

--- a/dozer/cogs/general.py
+++ b/dozer/cogs/general.py
@@ -1,5 +1,5 @@
 import discord, inspect
-from discord.ext.commands import BadArgument, Group
+from discord.ext.commands import BadArgument, Group, bot_has_permissions
 from ._utils import *
 
 class General(Cog):
@@ -20,6 +20,7 @@ class General(Cog):
 	"""
 	
 	@command(name='help', aliases=['about'])
+	@bot_has_permissions(add_reactions=True)
 	async def base_help(self, ctx, *target):
 		"""Show this message."""
 		if not target: # No commands - general help

--- a/dozer/cogs/general.py
+++ b/dozer/cogs/general.py
@@ -1,5 +1,5 @@
 import discord
-from discord.ext.commands import BadArgument
+from discord.ext.commands import BadArgument, Group
 from ._utils import *
 
 class General(Cog):
@@ -44,14 +44,27 @@ class General(Cog):
 			page = discord.Embed(color=discord.Color.blue())
 			for command in page_commands:
 				page.add_field(name=ctx.prefix + command.signature, value=command.help.splitlines()[0], inline=False)
-			page.set_footer(text='Page {} of {}'.format(page_num + 1, len(command_chunks)))
+			page.set_footer(text='Dozer Help | Page {} of {}'.format(page_num + 1, len(command_chunks)))
 			pages.append(page)
 		await paginate(ctx, pages, auto_remove=ctx.channel.permissions_for(ctx.me))
 	
 	async def _help_command(self, ctx, command):
 		"""Gets the help message for one command."""
-		await ctx.send('help command {}'.format(command))
-		# TODO show help on specific command and its subcommands
+		if not isinstance(command, Group):
+			e = discord.Embed(title=ctx.prefix + command.signature, description=command.help, color=discord.Color.blue())
+			e.set_footer(text='Dozer Help | {}'.format(command.qualified_name))
+			await ctx.send(embed=e)
+			return
+		
+		pages = []
+		command_chunks = list(chunk(sorted(command.commands, key=lambda cmd: cmd.qualified_name), 4))
+		for page_num, page_commands in enumerate(command_chunks):
+			page = discord.Embed(title=ctx.prefix + command.signature, description=command.help, color=discord.Color.blue())
+			for command in page_commands:
+				page.add_field(name=ctx.prefix + command.signature, value=command.help.splitlines()[0], inline=False)
+			page.set_footer(text='Dozer Help | {} | Page {} of {}'.format(command.qualified_name, page_num + 1, len(command_chunks)))
+			pages.append(page)
+		await paginate(ctx, pages, auto_remove=ctx.channel.permissions_for(ctx.me))
 	
 	async def _help_cog(self, ctx, cog):
 		"""Gets the help message for one cog."""

--- a/dozer/cogs/general.py
+++ b/dozer/cogs/general.py
@@ -52,6 +52,10 @@ class General(Cog):
 		info = discord.Embed(title='Dozer: Info', description='A guild management bot for FIRST Discord servers', color=discord.Color.blue())
 		info.set_thumbnail(url=self.bot.user.avatar_url)
 		info.add_field(name='About', value="Dozer: A collaborative bot for FIRST Discord servers, developed by the FRC Discord Server Development Team")
+		info.add_field(name='About `{}{}`'.format(ctx.prefix, ctx.invoked_with), value=inspect.cleandoc("""
+		This command can show info for all commands, a specific command, or a category of commands.
+		Use `{0}{1} {1}` for more information.
+		""".format(ctx.prefix, ctx.invoked_with)), inline=False)
 		info.add_field(name='Support', value="Join our development server at https://discord.gg/bB8tcQ8 for support, to help with development, or if you have any questions or comments!")
 		info.set_footer(text='Dozer Help | all commands | Info page')
 		await self._show_help(ctx, info, 'Dozer: Commands', '', 'all commands', ctx.bot.commands)

--- a/dozer/cogs/general.py
+++ b/dozer/cogs/general.py
@@ -3,6 +3,7 @@ from discord.ext.commands import BadArgument, Group
 from ._utils import *
 
 class General(Cog):
+	"""General commands common to all Discord bots."""
 	@command()
 	async def ping(self, ctx):
 		"""Check the bot is online, and calculate its response time."""
@@ -60,16 +61,25 @@ class General(Cog):
 		command_chunks = list(chunk(sorted(command.commands, key=lambda cmd: cmd.qualified_name), 4))
 		for page_num, page_commands in enumerate(command_chunks):
 			page = discord.Embed(title=ctx.prefix + command.signature, description=command.help, color=discord.Color.blue())
-			for command in page_commands:
-				page.add_field(name=ctx.prefix + command.signature, value=command.help.splitlines()[0], inline=False)
+			for subcommand in page_commands:
+				page.add_field(name=ctx.prefix + subcommand.signature, value=subcommand.help.splitlines()[0], inline=False)
 			page.set_footer(text='Dozer Help | {} | Page {} of {}'.format(command.qualified_name, page_num + 1, len(command_chunks)))
 			pages.append(page)
 		await paginate(ctx, pages, auto_remove=ctx.channel.permissions_for(ctx.me))
 	
 	async def _help_cog(self, ctx, cog):
 		"""Gets the help message for one cog."""
-		await ctx.send('help cog {}'.format(type(cog).__name__))
-		# TODO show top-level help on all commands in this cog
+		cog_name = type(cog).__name__
+		commands = sorted((command for command in ctx.bot.commands if command.instance is cog), key=lambda cmd: cmd.qualified_name)
+		command_chunks = list(chunk(commands, 4))
+		pages = []
+		for page_num, page_commands in enumerate(command_chunks):
+			page = discord.Embed(title=cog_name, description=cog.__doc__, color=discord.Color.blue())
+			for command in page_commands:
+				page.add_field(name=ctx.prefix + command.signature, value=command.help.splitlines()[0], inline=False)
+			page.set_footer(text='Dozer Help | {} cog | Page {} of {}'.format(cog_name, page_num + 1, len(command_chunks)))
+			pages.append(page)
+		await paginate(ctx, pages, auto_remove=ctx.channel.permissions_for(ctx.me))
 
 def setup(bot):
 	bot.remove_command('help')

--- a/dozer/cogs/general.py
+++ b/dozer/cogs/general.py
@@ -1,4 +1,4 @@
-import discord
+import discord, inspect
 from discord.ext.commands import BadArgument, Group
 from ._utils import *
 
@@ -67,7 +67,7 @@ class General(Cog):
 	
 	async def _help_cog(self, ctx, cog):
 		"""Gets the help message for one cog."""
-		await self._show_help(ctx, None, 'Category: {cog_name}', cog.__doc__ or '', '{cog_name!r} category', (command for command in ctx.bot.commands if command.instance is cog), cog_name=type(cog).__name__)
+		await self._show_help(ctx, None, 'Category: {cog_name}', inspect.cleandoc(cog.__doc__ or ''), '{cog_name!r} category', (command for command in ctx.bot.commands if command.instance is cog), cog_name=type(cog).__name__)
 	
 	async def _show_help(self, ctx, start_page, title, description, footer, commands, **format_args):
 		"""Creates and sends a template help message, with arguments filled in."""

--- a/dozer/cogs/info.py
+++ b/dozer/cogs/info.py
@@ -46,15 +46,6 @@ class Info(Cog):
 		e.add_field(name='Region', value=guild.region.name)
 		e.add_field(name='Icon URL', value=guild.icon_url or 'This guild has no icon.')
 		await ctx.send(embed=e)
-	
-	@command()
-	async def about(self, ctx):
-		"""Shows information about the bot"""
-		e = discord.Embed(color=discord.Color.blue())
-		e.set_thumbnail(url=self.bot.user.avatar_url)
-		e.add_field(name='About', value="Dozer: A collaborative bot for FIRST Discord servers, developed by the FRC Discord Server Development Team")
-		e.add_field(name='Support', value="Join our development server at https://discord.gg/bB8tcQ8 for support, to help with development, or if you have any questions or comments!")
-		await ctx.send(embed=e)
 
 def setup(bot):
 	bot.add_cog(Info(bot))

--- a/dozer/cogs/info.py
+++ b/dozer/cogs/info.py
@@ -8,8 +8,18 @@ datetime_format = '%Y-%m-%d %I:%M %p'
 class Info(Cog):
 	@guild_only()
 	@command(aliases=['user', 'userinfo', 'memberinfo'])
-	async def member(self, ctx, member : discord.Member = None):
-		"""Retrieve information about a member of the guild."""
+	async def member(self, ctx, member: discord.Member=None):
+		"""
+		Retrieve information about a member of the guild.
+		If no arguments are passed, information about the author is used.
+		**This command works without mentions.** Remove the '@' before your mention so you don't ping the person unnecessarily.
+		You can pick a member by:
+		- Username (`cooldude`)
+		- Username and discriminator (`cooldude#1234`)
+		- ID (`326749693969301506`)
+		- Nickname - must be exact and is case-sensitive (`"Mr. Cool Dude III | Team 1234"`)
+		- Mention (not recommended) (`@Mr Cool Dude III | Team 1234`)
+		"""
 		async with ctx.typing():
 			member = member or ctx.author
 			icon_url = member.avatar_url_as(static_format='png')
@@ -27,6 +37,11 @@ class Info(Cog):
 			e.add_field(name='Roles', value=', '.join(role.name for role in roles), inline=False)
 			e.add_field(name='Icon URL', value=icon_url, inline=False)
 		await ctx.send(embed=e)
+	
+	member.example_usage = """
+	`{prefix}member` - get information about yourself
+	`{prefix}member cooldude#1234` - get information about cooldude
+	"""
 	
 	@guild_only()
 	@command(aliases=['server', 'guildinfo', 'serverinfo'])
@@ -46,6 +61,10 @@ class Info(Cog):
 		e.add_field(name='Region', value=guild.region.name)
 		e.add_field(name='Icon URL', value=guild.icon_url or 'This guild has no icon.')
 		await ctx.send(embed=e)
+	
+	guild.example_usage = """
+	`{prefix}guild` - get information about this guild
+	"""
 
 def setup(bot):
 	bot.add_cog(Info(bot))

--- a/dozer/cogs/info.py
+++ b/dozer/cogs/info.py
@@ -6,6 +6,7 @@ blurple = discord.Color.blurple()
 datetime_format = '%Y-%m-%d %I:%M %p'
 
 class Info(Cog):
+	"""Commands for getting information about people and things on Discord."""
 	@guild_only()
 	@command(aliases=['user', 'userinfo', 'memberinfo'])
 	async def member(self, ctx, member: discord.Member=None):

--- a/dozer/cogs/maintenance.py
+++ b/dozer/cogs/maintenance.py
@@ -15,6 +15,10 @@ class Maintenance(Cog):
 		print('Shutting down at request of {0.author} (in {0.guild}, #{0.channel})'.format(ctx))
 		await self.bot.shutdown()
 	
+	shutdown.example_usage = """
+	`{prefix}shutdown` - stop the bot
+	"""
+	
 	@command()
 	async def restart(self, ctx):
 		"""Restarts the bot."""
@@ -30,15 +34,27 @@ class Maintenance(Cog):
 			args = [sys.executable, script]
 		os.execv(sys.executable, args + sys.argv[1:])
 	
+	restart.example_usage = """
+	`{prefix}restart` - restart the bot
+	"""
+	
 	@command()
 	async def update(self, ctx):
-		"""Pulls code from GitHub and restarts."""
+		"""
+		Pulls code from GitHub and restarts.
+		This pulls from whatever repository `origin` is linked to.
+		If there are changes to download, and the download is successful, the bot restarts to apply changes.
+		"""
 		res = os.popen("git pull origin master").read()
 		if res.startswith('Already up-to-date.'):
 			await ctx.send('```\n' + res + '```')
 		else:
 			await ctx.send('```\n' + res + '```')
 			await ctx.bot.get_command('restart').callback(self, ctx)
+	
+	update.example_usage = """
+	`{prefix}update` - update to the latest commit and restart
+	"""
 
 def setup(bot):
 	bot.add_cog(Maintenance(bot))

--- a/dozer/cogs/maintenance.py
+++ b/dozer/cogs/maintenance.py
@@ -3,6 +3,10 @@ from ._utils import *
 from discord.ext.commands import NotOwner
 
 class Maintenance(Cog):
+	"""
+	Commands for performing maintenance on the bot.
+	These commands are restricted to bot developers.
+	"""
 	def __local_check(self, ctx): # All of this cog is only available to devs
 		if ctx.author.id not in ctx.bot.config['developers']:
 			raise NotOwner('you are not a developer!')

--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -18,6 +18,10 @@ class Moderation(Cog):
 		howtounban = "When it's time to unban, here's the ID to unban: <@" + bannedid + " >"
 		await ctx.send(howtounban)
 	
+	ban.example_usage = """
+	`{prefix}ban cooldude#1234` - Bans cooldude
+	"""
+	
 	@command()
 	@has_permissions(ban_members=True)
 	@bot_has_permissions(ban_members=True)
@@ -30,15 +34,27 @@ class Moderation(Cog):
 		await ctx.guild.unban(usertoban)
 		await ctx.send(usertobanstr + "has been unbanned")
 	
+	unban.example_usage = """
+	`{prefix}unban cooldude#1234` - Unbans cooldude
+	"""
+	
 	@command()
 	@has_permissions(kick_members=True)
 	@bot_has_permissions(kick_members=True)
 	async def kick(self, ctx, user_mentions: discord.User):
-		"Kicks the user mentioned."
+		"""
+		Kicks the user mentioned.
+		This does not prevent the user from rejoining.
+		If there is a public invite to your server, the user may rejoin.
+		"""
 		usertokick = user_mentions
 		usertokickstr = str(usertokick)
 		await ctx.guild.kick(usertokick)
 		await ctx.send(usertokickstr + " has been kicked")
+	
+	kick.example_usage = """
+	`{prefix}kick cooldude#1234` - Kicks cooldude
+	"""
 
 def setup(bot):
 	bot.add_cog(Moderation(bot))

--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -4,6 +4,11 @@ from ._utils import *
 import discord
 
 class Moderation(Cog):
+	"""
+	Moderation commands for simplifying and improving Discord's moderation tools.
+	These commands are restricted to users who have permission to do the action manually.
+	For example, the ban and unban commands require permission to ban members.
+	"""
 	@command()
 	@has_permissions(ban_members=True)
 	@bot_has_permissions(ban_members=True)

--- a/dozer/cogs/roles.py
+++ b/dozer/cogs/roles.py
@@ -201,6 +201,7 @@ class Roles(Cog):
 	@bot_has_permissions(manage_roles=True)
 	@has_permissions(manage_roles=True)
 	async def take(self, ctx, member : discord.Member, *, role : discord.Role):
+		"""Removes a role from a member. Not restricted to giveable roles."""
 		await member.remove_roles(role)
 		await ctx.send('Successfully removed "{}" from {}!'.format(role, member))
 

--- a/dozer/cogs/roles.py
+++ b/dozer/cogs/roles.py
@@ -5,6 +5,7 @@ from .. import db
 from ._utils import *
 
 class Roles(Cog):
+	"""Commands for role management."""
 	async def on_member_join(self, member):
 		me = member.guild.me
 		top_restoreable = me.top_role.position if me.guild_permissions.manage_roles else 0

--- a/dozer/cogs/roles.py
+++ b/dozer/cogs/roles.py
@@ -79,6 +79,11 @@ class Roles(Cog):
 			e.add_field(name='{} role(s) could not be found!'.format(extra), value='Use `{0.prefix}{0.invoked_with} list` to find valid giveable roles!'.format(ctx), inline=False)
 		await ctx.send(embed=e)
 	
+	giveme.example_usage = """
+	`{prefix}giveme Java` - gives you the role called Java, if it exists
+	`{prefix}giveme Java, Python` - gives you the roles called Java and Python, if they exist
+	"""
+	
 	@giveme.command()
 	@bot_has_permissions(manage_roles=True)
 	@has_permissions(manage_guild=True)
@@ -106,6 +111,11 @@ class Roles(Cog):
 			settings.giveable_roles.append(GiveableRole.from_role(role))
 		await ctx.send('Role "{0}" added! Use `{1}{2} {0}` to get it!'.format(role.name, ctx.prefix, ctx.command.parent))
 	
+	add.example_usage = """
+	`{prefix}giveme add Java` - creates or finds a role named "Java" and makes it giveable
+	`{prefix}giveme Java` - gives you the Java role that was just found or created
+	"""
+	
 	@giveme.command()
 	@bot_has_permissions(manage_roles=True)
 	@has_permissions(manage_guild=True)
@@ -126,6 +136,11 @@ class Roles(Cog):
 			role = await ctx.guild.create_role(name=name, reason='Giveable role created by {}'.format(ctx.author))
 			settings.giveable_roles.append(GiveableRole.from_role(role))
 		await ctx.send('Role "{0}" created! Use `{1}{2} {0}` to get it!'.format(role.name, ctx.prefix, ctx.command.parent))
+	
+	create.example_usage = """
+	`{prefix}giveme create Python` - creates a role named "Python" and makes it giveable
+	`{prefix}giveme Python` - gives you the Python role that was just created
+	"""
 	
 	@giveme.command()
 	@bot_has_permissions(manage_roles=True)
@@ -153,6 +168,11 @@ class Roles(Cog):
 			e.add_field(name='{} role(s) could not be found!'.format(extra), value='Use `{0.prefix}{0.invoked_with} list` to find valid giveable roles!'.format(ctx), inline=False)
 		await ctx.send(embed=e)
 	
+	remove.example_usage = """
+	`{prefix}giveme remove Java` - removes the role called "Java" from you (if it can be given with `{prefix}giveme`)
+	`{prefix}giveme remove Java, Python` - removes the roles called "Java" and "Python" from you
+	"""
+	
 	@giveme.command()
 	@bot_has_permissions(manage_roles=True)
 	@has_permissions(manage_guild=True)
@@ -175,6 +195,10 @@ class Roles(Cog):
 		await role.delete(reason='Giveable role deleted by {}'.format(ctx.author))
 		await ctx.send('Role "{0}" deleted!'.format(role))
 	
+	delete.example_usage = """
+	`{prefix}giveme delete Java` - deletes the role called "Java" if it's giveable (automatically removes it from all members)
+	"""
+	
 	@giveme.command(name='list')
 	@bot_has_permissions(manage_roles=True)
 	async def list_roles(self, ctx):
@@ -184,6 +208,10 @@ class Roles(Cog):
 		e = discord.Embed(title='Roles available to self-assign', color=discord.Color.blue())
 		e.description = '\n'.join(sorted(names, key=str.casefold))
 		await ctx.send(embed=e)
+	
+	list_roles.example_usage = """
+	`{prefix}giveme list` - lists all giveable roles
+	"""
 	
 	@staticmethod
 	def normalize(name):
@@ -197,6 +225,10 @@ class Roles(Cog):
 		await member.add_roles(role)
 		await ctx.send('Successfully gave {} "{}"!'.format(member, role))
 	
+	give.example_usage = """
+	`{prefix}give cooldude#1234 Java` - gives cooldude any role, giveable or not, named Java
+	"""
+	
 	@command()
 	@bot_has_permissions(manage_roles=True)
 	@has_permissions(manage_roles=True)
@@ -204,6 +236,10 @@ class Roles(Cog):
 		"""Takes a role from a member. Not restricted to giveable roles."""
 		await member.remove_roles(role)
 		await ctx.send('Successfully removed "{}" from {}!'.format(role, member))
+	
+	take.example_usage = """
+	`{prefix}take cooldude#1234 Java` - takes any role named Java, giveable or not, from cooldude
+	"""
 
 class GuildSettings(db.DatabaseObject):
 	__tablename__ = 'guilds'


### PR DESCRIPTION
- [x] Add `&help`, a command to show information about the bot, a specific command, or a cog
- [x] Alias `&about` to `&help`, as `&help` now contains all of the information from `&about` and more
- [x] Add custom command and group classes with example usage
- [x] Add help and example usage for every command
- [x] Add help information for cogs