### PR TITLE
Globally block the bot from using mass mentions

### DIFF
--- a/dozer/bot.py
+++ b/dozer/bot.py
@@ -8,6 +8,12 @@ class InvalidContext(commands.CheckFailure):
 	The message will be ignored.
 	"""
 
+class DozerContext(commands.Context):
+	async def send(self, content=None, **kwargs):
+		if content is not None:
+			content = utils.clean(self, content, mass=True, member=False, role=False, channel=False)
+		return await super().send(content, **kwargs)
+
 class Dozer(commands.Bot):
 	_global_cooldown = commands.Cooldown(1, 1, commands.BucketType.user) # One command per second per user
 	def __init__(self, config):
@@ -18,6 +24,10 @@ class Dozer(commands.Bot):
 	async def on_ready(self):
 		print('Signed in as {0!s} ({0.id})'.format(self.user))
 		await self.change_presence(game=discord.Game(name='%shelp | %d guilds' % (self.config['prefix'], len(self.guilds))))
+	
+	async def get_context(self, message):
+		ctx = await super().get_context(message, cls=DozerContext)
+		return ctx
 	
 	async def on_command_error(self, ctx, err):
 		if isinstance(err, commands.NoPrivateMessage):

--- a/dozer/utils.py
+++ b/dozer/utils.py
@@ -7,13 +7,17 @@ member_mention = re.compile(r'<@\!?(\d+)>')
 role_mention = re.compile(r'<@&(\d+)>')
 channel_mention = re.compile(r'<#(\d+)>')
 
-def clean(ctx, text=None, *, clean_channels=True):
+def clean(ctx, text=None, *, mass=True, member=True, role=True, channel=True):
 	if text is None:
 		text = ctx.message.content
-	cleaned_text = mass_mention.sub(lambda match: '@\N{ZERO WIDTH SPACE}' + match.group(1), text)
-	cleaned_text = member_mention.sub(lambda match: clean_member_name(ctx, int(match.group(1))), cleaned_text)
-	cleaned_text = role_mention.sub(lambda match: clean_role_name(ctx, int(match.group(1))), cleaned_text)
-	cleaned_text = channel_mention.sub(lambda match: clean_channel_name(ctx, int(match.group(1))), cleaned_text)
+	if mass:
+		cleaned_text = mass_mention.sub(lambda match: '@\N{ZERO WIDTH SPACE}' + match.group(1), text)
+	if member:
+		cleaned_text = member_mention.sub(lambda match: clean_member_name(ctx, int(match.group(1))), cleaned_text)
+	if role:
+		cleaned_text = role_mention.sub(lambda match: clean_role_name(ctx, int(match.group(1))), cleaned_text)
+	if channel:
+		cleaned_text = channel_mention.sub(lambda match: clean_channel_name(ctx, int(match.group(1))), cleaned_text)
 	return cleaned_text
 
 def is_clean(ctx, text=None):


### PR DESCRIPTION
@.everyone and @.here will automatically be removed, by inserting a zero-width space after the "@". To block user, role, or channel mentions in the future, simply replace the respective enable the respective filter in DozerContext.send.