### PR TITLE
Timeout command

### DIFF
--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -142,10 +142,13 @@ class Moderation(Cog):
 		Set the member role for the guild.
 		The member role is the role used for the timeout command. It should be a role that all members of the server have.
 		"""
+		if member_role >= ctx.author.top_role:
+			raise BadArgument('member role cannot be higher than your top role!')
+		
 		with db.Session() as session:
 			settings = session.query(MemberRole).filter_by(id=ctx.guild.id).one_or_none()
 			if settings is None:
-				settings = MemberRole(id=ctx.guild.id, name=ctx.guild.name, member_role=member_role.id)
+				settings = MemberRole(id=ctx.guild.id, member_role=member_role.id)
 				session.add(settings)
 			else:
 				settings.member_role = member_role.id

--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -8,7 +8,7 @@ class SafeRoleConverter(RoleConverter):
 		try:
 			return await super().convert(ctx, arg)
 		except BadArgument:
-			if arg.casefold() in ('everyone', '@everyone', '@.everyone', '@ everyone', '@\N{ZERO WIDTH SPACE}everyone'):
+			if arg.casefold() in ('everyone', '@everyone', '@/everyone', '@.everyone', '@ everyone', '@\N{ZERO WIDTH SPACE}everyone'):
 				return ctx.guild.default_role
 			else:
 				raise

--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -92,7 +92,7 @@ class Moderation(Cog):
 			await ctx.send('{0.author.mention}, the members role has not been configured. This may not work as expected. Use `{0.prefix}help memberconfig` to see how to set this up.'.format(ctx))
 			targets = {target for target, overwrite in ctx.channel.overwrites if overwrite.send_messages or overwrite.add_reactions and (target if isinstance(target, discord.Role) else target.top_role) < ctx.me.top_role}
 		
-		to_restore = [tup for tup in ctx.channel.overwrites if tup[0] in targets]
+		to_restore = [(target, ctx.channel.overwrites_for(target)) for target in targets]
 		for target, overwrite in to_restore:
 			new_overwrite = discord.PermissionOverwrite.from_pair(*overwrite.pair())
 			new_overwrite.update(send_messages=False, add_reactions=False)

--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -163,6 +163,7 @@ class Moderation(Cog):
 	`{prefix}memberconfig @/everyone` - set the default role as the member role (ping-safe)
 	"""
 	
+	@command()
 	@has_permissions(administrator=True)
 	async def memberlogconfig(self, ctx, channel_mentions: discord.TextChannel):
 		"""Set the modlog channel for a server by passing the channel id"""

--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -105,10 +105,20 @@ class Moderation(Cog):
 			await ctx.channel.set_permissions(allow_target, overwrite=new_overwrite)
 			to_restore.append((allow_target, overwrite))
 		
+		e = discord.Embed(title='Timeout - {}s'.format(duration), description='This channel has been timed out.', color=discord.Color.blue())
+		e.set_author(name=ctx.author.display_name, icon_url=ctx.author.avatar_url_as(format='png', size=32))
+		msg = await ctx.send(embed=e)
+		
 		await asyncio.sleep(duration)
 		
 		for target, overwrite in to_restore:
-			await ctx.channel.set_permissions(target, overwrite=overwrite)
+			if all(permission is None for _, permission in overwrite):
+				await ctx.channel.set_permissions(target, overwrite=None)
+			else:
+				await ctx.channel.set_permissions(target, overwrite=overwrite)
+		
+		e.description = 'The timeout has ended.'
+		await msg.edit(embed=e)
 	
 	timeout.example_usage = """
 	`{prefix}timeout 60` - prevents sending messages in this channel for 1 minute (60s)


### PR DESCRIPTION
- `timeout` command to disable sending message and adding reactions
  - If no member role is set, every role under the caller's top role is muted and the caller is warned
  - If a role is set, that role is muted
  - The bot and the caller can send messages, to give everyone a stern talking-to while they're listening
- `memberconfig` command to set a members role
  - This role is muted during a timeout
  - Cannot be the caller's top role or any role higher than it
  - This role should be the most inclusive role that gives send message and add reaction permissions
  - To set the default role as the members role, use any of `@everyone`, `@.everyone`, `@/everyone`, `@ everyone`, or `@​everyone` (with a zero-width space)