### PR TITLE
Remove motto from TBA

### DIFF
--- a/dozer/cogs/tba.py
+++ b/dozer/cogs/tba.py
@@ -40,7 +40,6 @@ class TBA(Cog):
 		e.add_field(name='Rookie Year', value=team_data.rookie_year)
 		e.add_field(name='Location', value=team_data.location)
 		e.add_field(name='Website', value=team_data.website)
-		e.add_field(name='Motto', value=team_data.motto)
 		e.set_footer(text='Triggered by ' + ctx.author.display_name)
 		await ctx.send(embed=e)
 	


### PR DESCRIPTION
Because the "motto" for a team is no longer editable by teams through TIMS (or whatever they're calling the new system) as well as not showing up on any forward facing UI (The Blue Alliance, firstinspires search, frc-events search, etc). It shouldn't be displayed because of this unoffical deprecation, even if it's still in the API.