### PR TITLE
Add stopgap TOA functionality

### DIFF
--- a/dozer/__main__.py
+++ b/dozer/__main__.py
@@ -1,7 +1,7 @@
 import json, os.path, sys
 from . import db
 
-config = {'prefix': '&', 'developers': [], 'tba': {'team': '', 'application': '', 'version': ''}, 'gmaps_key': "PUT GOOGLE MAPS API KEY HERE", 'discord_token': "Put Discord API Token here."}
+config = {'prefix': '&', 'developers': [], 'tba': {'team': '', 'application': '', 'version': ''}, 'toa_key': "Put TOA API key here", 'gmaps_key': "PUT GOOGLE MAPS API KEY HERE", 'discord_token': "Put Discord API Token here."}
 config_file = 'config.json'
 
 if os.path.isfile(config_file):

--- a/dozer/__main__.py
+++ b/dozer/__main__.py
@@ -1,7 +1,20 @@
 import json, os.path, sys
 from . import db
 
-config = {'prefix': '&', 'developers': [], 'tba': {'team': '', 'application': '', 'version': ''}, 'toa_key': "Put TOA API key here", 'gmaps_key': "PUT GOOGLE MAPS API KEY HERE", 'discord_token': "Put Discord API Token here."}
+config = {
+	'prefix': '&', 'developers': [], 
+	'tba': {
+		'team': '',
+		'application': '', 
+		'version': ''
+	}, 
+	'toa': {
+		'key': 'Put TOA API key here', 
+		'app_name': 'Dozer',
+	},
+	'gmaps_key': "PUT GOOGLE MAPS API KEY HERE", 
+	'discord_token': "Put Discord API Token here."
+}
 config_file = 'config.json'
 
 if os.path.isfile(config_file):
@@ -14,8 +27,8 @@ with open('config.json', 'w') as f:
 if 'discord_token' not in config:
 	sys.exit('Discord token must be supplied in configuration')
 
-if sys.version_info < (3, 5):
-	sys.exit('Dozer requires Python 3.5 or higher to run. This is version %s.' % '.'.join(sys.version_info[:3]))
+if sys.version_info < (3, 6):
+	sys.exit('Dozer requires Python 3.6 or higher to run. This is version %s.' % '.'.join(sys.version_info[:3]))
 
 from . import Dozer # After version check
 

--- a/dozer/cogs/_toa.py
+++ b/dozer/cogs/_toa.py
@@ -1,30 +1,50 @@
 import aiohttp
 import async_timeout
+import json
+from asyncio import sleep
+from datetime import datetime
 from urllib.parse import urljoin
+
 
 class TOAParser(object):
 	"""
 	A class to make async requests to The Orange Alliance.
 	"""
-	def __init__(self, api_key, base_url="https://theorangealliance.org/apiv2/", app_name="Dozer"):
+	def __init__(self, api_key, aiohttp_session, base_url="https://theorangealliance.org/apiv2/", app_name="Dozer", ratelimit=True):
+		self.last_req = datetime.now()
+		self.ratelimit = ratelimit
 		self.base = base_url
+		self.http = aiohttp_session
 		self.headers = {
 			"X-Application-Origin": app_name,
 			"X-TOA-Key": api_key
 		}
 
 	async def req(self, endpoint):
-		"""Make an async request at the specified endpoint."""
-		async with aiohttp.ClientSession() as session:
-			with async_timeout.timeout(5):
-				async with session.get(urljoin(self.base, endpoint), headers=self.headers) as response:
+		"""Make an async request at the specified endpoint, waiting to let the ratelimit cool off."""
+		if self.ratelimit:
+			# this will delay a request to avoid the ratelimit
+			now = datetime.now()
+			diff = (now - self.last_req).total_seconds()
+			self.last_req = now
+			if diff < 2.2: # have a 200 ms fudge factor
+				await sleep(2.2 - diff)
+		tries = 0
+		while True:
+			try:
+				async with async_timeout.timeout(5) as _, self.http.get(urljoin(self.base, endpoint), headers=self.headers) as response:
 					res = TOAResponse()
-					data = await response.json()
+					# it seems sometimes toa forgets to return data as application/json and not text/html
+					data = json.loads(await response.text())
 					if data:
 						res._update(data[0])
 					else:
 						res.error = True
 					return res
+			except aiohttp.ClientError:
+				tries += 1	
+				if tries > 3:
+					raise
 
 class TOAResponse(object):
 	def __init__(self):

--- a/dozer/cogs/_toa.py
+++ b/dozer/cogs/_toa.py
@@ -1,0 +1,29 @@
+import aiohttp
+import async_timeout
+from urllib.parse import urljoin
+
+class TOAParser(object):
+	"""
+	A class to make async requests to The Orange Alliance.
+	"""
+	def __init__(self, api_key, base_url="https://beta.theorangealliance.org/api/", app_name="Dozer"):
+		self.base = base_url
+		self.headers = {
+			"X-Application-Origin": app_name,
+			"X-TOA-Key": api_key
+		}
+
+	async def req(self, endpoint):
+		"""Make an async request at the specified endpoint."""
+		async with aiohttp.ClientSession() as session:
+			with async_timeout.timeout(5):
+				async with session.get(urljoin(self.base, endpoint), headers=self.headers) as response:
+					res = TOAResponse()
+					res._update((await response.json())[0])
+					return res
+
+class TOAResponse(object):
+	def __init__(self):
+		self.error = None
+	def _update(self, v):
+		self.__dict__.update(v)

--- a/dozer/cogs/_toa.py
+++ b/dozer/cogs/_toa.py
@@ -6,7 +6,7 @@ class TOAParser(object):
 	"""
 	A class to make async requests to The Orange Alliance.
 	"""
-	def __init__(self, api_key, base_url="https://beta.theorangealliance.org/api/", app_name="Dozer"):
+	def __init__(self, api_key, base_url="https://theorangealliance.org/apiv2/", app_name="Dozer"):
 		self.base = base_url
 		self.headers = {
 			"X-Application-Origin": app_name,

--- a/dozer/cogs/_toa.py
+++ b/dozer/cogs/_toa.py
@@ -19,11 +19,15 @@ class TOAParser(object):
 			with async_timeout.timeout(5):
 				async with session.get(urljoin(self.base, endpoint), headers=self.headers) as response:
 					res = TOAResponse()
-					res._update((await response.json())[0])
+					data = await response.json()
+					if data:
+						res._update(data[0])
+					else:
+						res.error = True
 					return res
 
 class TOAResponse(object):
 	def __init__(self):
-		self.error = None
+		self.error = False
 	def _update(self, v):
 		self.__dict__.update(v)

--- a/dozer/cogs/toa.py
+++ b/dozer/cogs/toa.py
@@ -29,6 +29,10 @@ class TOA(Cog):
 	async def team(self, ctx, team_num: int):
 		"""Get information on an FTC team by number."""
 		team_data = await self.parser.req("team/" + str(team_num))
+		if team_data.error:
+			await ctx.send("This team does not have any data on it yet, or it does not exist!")
+			return
+
 		e = discord.Embed(color=embed_color)
 		e.set_author(name='FIRST® Tech Challenge Team {}'.format(team_num), url='https://www.theorangealliance.org/teams/'.format(team_num), icon_url='https://cdn.discordapp.com/icons/342152047753166859/de4d258c0cab5bee0b04d406172ec585.jpg')
 		e.add_field(name='Name', value=team_data.team_name_short)

--- a/dozer/cogs/toa.py
+++ b/dozer/cogs/toa.py
@@ -1,0 +1,48 @@
+import discord
+import datetime
+from ._utils import *
+from ._toa import *
+from discord.ext import commands
+from discord.ext.commands import BadArgument, Group, bot_has_permissions, has_permissions
+from datetime import timedelta
+
+embed_color = discord.Color(0xff9800)
+class TOA(Cog):
+	def __init__(self, bot):
+		super().__init__(bot)
+		self.parser = TOAParser(bot.config['toa_key'])
+	
+	@group(invoke_without_command=True)
+	async def toa(self, ctx, team_num: int):
+		"""
+		Get FTC-related information from The Orange Alliance.
+		If no subcommand is specified, the `team` subcommand is inferred, and the argument is taken as a team number.
+		"""
+		await self.team.callback(self, ctx, team_num)
+	
+	toa.example_usage = """
+	`{prefix}toa 5667` - show information on team 5667, the Robominers
+	"""
+	
+	@toa.command()
+	@bot_has_permissions(embed_links=True)
+	async def team(self, ctx, team_num: int):
+		"""Get information on an FTC team by number."""
+		team_data = await self.parser.req("team/" + str(team_num))
+		e = discord.Embed(color=embed_color)
+		e.set_author(name='FIRST® Tech Challenge Team {}'.format(team_num), url='https://www.theorangealliance.org/teams/'.format(team_num), icon_url='https://cdn.discordapp.com/icons/342152047753166859/de4d258c0cab5bee0b04d406172ec585.jpg')
+		e.add_field(name='Name', value=team_data.team_name_short)
+		e.add_field(name='Rookie Year', value=team_data.rookie_year)
+		e.add_field(name='Location', value=', '.join((team_data.city, team_data.state_prov, team_data.country)))
+		e.add_field(name='Website', value=team_data.website or "n/a")
+		e.add_field(name='FTCRoot Page', value='http://www.ftcroot.com/teams/{}'.format(team_num))
+		e.set_footer(text='Triggered by ' + ctx.author.display_name)
+		await ctx.send(embed=e)
+
+	
+	team.example_usage = """
+	`{prefix}toa team 12670` - show information on team 12670, Eclipse
+	"""
+
+def setup(bot):
+	bot.add_cog(TOA(bot))

--- a/dozer/cogs/toa.py
+++ b/dozer/cogs/toa.py
@@ -10,7 +10,7 @@ embed_color = discord.Color(0xff9800)
 class TOA(Cog):
 	def __init__(self, bot):
 		super().__init__(bot)
-		self.parser = TOAParser(bot.config['toa_key'], bot.http._session)
+		self.parser = TOAParser(bot.config['toa']['key'], bot.http._session, app_name=bot.config['toa']['app_name'])
 	
 	@group(invoke_without_command=True)
 	async def toa(self, ctx, team_num: int):

--- a/dozer/cogs/toa.py
+++ b/dozer/cogs/toa.py
@@ -34,7 +34,7 @@ class TOA(Cog):
 			return
 
 		e = discord.Embed(color=embed_color)
-		e.set_author(name='FIRST® Tech Challenge Team {}'.format(team_num), url='https://www.theorangealliance.org/teams/'.format(team_num), icon_url='https://cdn.discordapp.com/icons/342152047753166859/de4d258c0cab5bee0b04d406172ec585.jpg')
+		e.set_author(name='FIRST® Tech Challenge Team {}'.format(team_num), url='https://www.theorangealliance.org/teams/{}'.format(team_num), icon_url='https://cdn.discordapp.com/icons/342152047753166859/de4d258c0cab5bee0b04d406172ec585.jpg')
 		e.add_field(name='Name', value=team_data.team_name_short)
 		e.add_field(name='Rookie Year', value=team_data.rookie_year)
 		e.add_field(name='Location', value=', '.join((team_data.city, team_data.state_prov, team_data.country)))

--- a/dozer/cogs/toa.py
+++ b/dozer/cogs/toa.py
@@ -10,7 +10,7 @@ embed_color = discord.Color(0xff9800)
 class TOA(Cog):
 	def __init__(self, bot):
 		super().__init__(bot)
-		self.parser = TOAParser(bot.config['toa_key'])
+		self.parser = TOAParser(bot.config['toa_key'], bot.http._session)
 	
 	@group(invoke_without_command=True)
 	async def toa(self, ctx, team_num: int):


### PR DESCRIPTION
This implements a basic toa command that has feature parity with where Robot-v5 was previously. I wasn't intending to submit this PR as it was mostly intended for the FTC server's Dozer, but Travis asked me to so here it is.

Please note that down the line `_toa.py` should be ostensibly be replaced with Ian's `toapy` down the line, as it's an awful hack - it simply stuffs the raw JSON data it gets into the attribute dictionary of what's essentially a data class, without doing any coercion to Pythonic types beyond what `json.loads` would give you. 