### PR TITLE
Permission fixes for help command

### DIFF
--- a/dozer/cogs/_utils.py
+++ b/dozer/cogs/_utils.py
@@ -70,7 +70,7 @@ class Reactor:
 		self.caller = ctx.author
 		self.me = ctx.me
 		self._reactions = tuple(initial_reactions)
-		self._remove_reactions = auto_remove
+		self._remove_reactions = auto_remove and ctx.channel.permissions_for(ctx.me).manage_messages # Check for required permissions
 		self.timeout = timeout
 		self._action = None
 	

--- a/dozer/cogs/general.py
+++ b/dozer/cogs/general.py
@@ -23,7 +23,7 @@ class General(Cog):
 	
 	@cooldown(1, 10, BucketType.channel)
 	@command(name='help', aliases=['about'])
-	@bot_has_permissions(add_reactions=True)
+	@bot_has_permissions(add_reactions=True, embed_links=True, read_message_history=True) # Message history is for internals of paginate()
 	async def base_help(self, ctx, *target):
 		"""Show this message."""
 		if not target: # No commands - general help


### PR DESCRIPTION
- Help command will no longer try to remove the user's reactions without the required Manage Messages permissions (fixes #44)
- Help command requires Embed Links and Read Message History permissions
  - Read Message History is for pagination only - single-page help works fine without it. However, considering most of the times I've seen the command used it's been for the general bot, and thus multiple pages, I don't think re-implementing the permission check for multi-page help messages only is worth the hassle.