### PR TITLE
moderation logging bugfix

### DIFF
--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -320,10 +320,10 @@ class Moderation(Cog):
 				e.add_field(name="New message", value=after.content[0:1023])
 				e.add_field(name="New message continued", value=after.content[1024:2000])
 			elif len(after.content) == 0 and after.edited_at is not None:
-				e.add_field(name="Title", value=i.title)
-				e.add_field(name="Description", value=i.description)
-				e.add_field(name="Timestamp", value=i.timestamp)
 				for i in after.embeds:
+					e.add_field(name="Title", value=i.title)
+					e.add_field(name="Description", value=i.description)
+					e.add_field(name="Timestamp", value=i.timestamp)
 					for x in i.fields:
 						e.add_field(name=x.name, value=x.value)
 			with db.Session() as session:


### PR DESCRIPTION
Considering that as is, Dozer will sometimes fail on certain edits....

edit: specifically, this error:
```python
Traceback (most recent call last):
  File "/[redacted]/Dozer-venv/lib/python3.6/site-packages/discord/client.py", line 223, in _run_event
    yield from coro(*args, **kwargs)
  File "/[redacted]/Dozer-upstream/dozer/cogs/moderation.py", line 323, in on_message_edit
    e.add_field(name="Title", value=i.title)
UnboundLocalError: local variable 'i' referenced before assignment
```
as i is referenced outside a for loop