### PR TITLE
Improve permoverride speed

### DIFF
--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -365,7 +365,7 @@ class Moderation(Cog):
 	@has_permissions(kick_members=True)
 	@bot_has_permissions(manage_roles=True)
 	async def mute(self, ctx, member_mentions: discord.Member, *, reason="No reason provided"):
-		with db.Session() as session:
+		async with ctx.typing(), db.Session() as session:
 			user = session.query(Guildmute).filter_by(id=member_mentions.id).one_or_none()
 			if user is not None:
 				await ctx.send("User is already muted!")
@@ -379,7 +379,7 @@ class Moderation(Cog):
 	@has_permissions(kick_members=True)
 	@bot_has_permissions(manage_roles=True)
 	async def unmute(self, ctx, member_mentions: discord.Member, reason="No reason provided"):
-		with db.Session() as session:
+		async with ctx.typing(), db.Session() as session:
 			user = session.query(Guildmute).filter_by(id=member_mentions.id, guild=ctx.guild.id).one_or_none()
 			if user is not None:
 				session.delete(user)
@@ -392,7 +392,7 @@ class Moderation(Cog):
 	@has_permissions(kick_members=True)
 	@bot_has_permissions(manage_roles=True)
 	async def deafen(self, ctx, member_mentions: discord.Member, *, reason="No reason provided"):
-		with db.Session() as session:
+		async with ctx.typing(), db.Session() as session:
 			user = session.query(Deafen).filter_by(id=member_mentions.id).one_or_none()
 			if user is not None:
 				await ctx.send("User is already deafened!")
@@ -405,8 +405,7 @@ class Moderation(Cog):
 	@command()
 	@bot_has_permissions(manage_roles=True)
 	async def selfdeafen(self, ctx, timing, *, reason="No reason provided"):
-		await ctx.send("Deafening {}...".format(ctx.author))
-		with db.Session() as session:
+		async with ctx.typing(), db.Session() as session:
 			user = session.query(Deafen).filter_by(id=ctx.author.id).one_or_none()
 			if user is not None:
 				await ctx.send("You are already deafened!")
@@ -424,7 +423,7 @@ class Moderation(Cog):
 	@has_permissions(kick_members=True)
 	@bot_has_permissions(manage_roles=True)
 	async def undeafen(self, ctx, member_mentions: discord.Member, reason="No reason provided"):
-		with db.Session() as session:
+		async with ctx.typing(), db.Session() as session:
 			user = session.query(Deafen).filter_by(id=member_mentions.id, guild=ctx.guild.id).one_or_none()
 			if user is not None:
 				await self.permoverride(user=member_mentions, read_messages=None)

--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -30,12 +30,12 @@ class Moderation(Cog):
 				await ctx.send("Please configure modlog channel to enable modlog functionality")
 
 	async def permoverride(self, user, **overwrites):
-		for i in user.guild.channels:
-			overwrite = i.overwrites_for(user)
+		coros = []
+		for channel in user.guild.channels:
+			overwrite = channel.overwrites_for(user)
 			overwrite.update(**overwrites)
-			await i.set_permissions(target=user, overwrite=overwrite)
-			if overwrite.is_empty():
-				await i.set_permissions(target=user, overwrite=None)
+			coros.append(channel.set_permissions(target=user, overwrite=None if overwrite.is_empty() else overwrite))
+		await asyncio.gather(*coros)
 
 	async def punishmenttimer(self, ctx, timing, target, lookup, reason):
 		regexstring = re.compile(r"((?P<hours>\d+)h)?((?P<minutes>\d+)m)?")


### PR DESCRIPTION
Each permoverride implementation was tested three times in a guild with 104 channels by evaluating this code:
```py
from datetime import datetime
po = ctx.bot.get_cog('Moderation').permoverride
start = datetime.utcnow()
await po(ctx.author, read_messages=False, add_reactions=False)
end = datetime.utcnow()
return (end - start).total_seconds()
```
Current method (seconds): 22.517, 19.926, 20.700, average 21.048  
New method (seconds): 3.759, 2.403, 3.118, average 3.124  
This results in an 85% increase in speed for the permoverride method, which is used for all muting and deafening. (The benefits for the commands are slightly smaller, since the database access is still there, but all commands now take ~ 5 seconds.)

These benefits are achieved by starting all `set_permissions` calls in parallel, rather than sequentially. This uses `asyncio.gather` instead of `AbstractEventLoop.create_task` so that permoverride still blocks until all requests are complete; this ensures that the mod-log message means the command completed successfully. Additionally, set_permissions is only called once if setting the permissions would result in an empty override, rather than once to set the empty override and once to remove it.

Because permission-setting commands still take some time to complete, this PR also adds typing notifications to the mute, deafen, unmute, undeafen, and selfdeafen commands to show immediate feedback that the command is working. This makes the `Deafening {}...` message in selfdeafen unnecessary.