### PR TITLE
Add fuzzywuzzy dependency to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ tbapi==1.3.1b2
 googlemaps
 datetime
 geopy
+fuzzywuzzy


### PR DESCRIPTION
I was doing a fresh install for a server and noticed that it failed out because I didn't have this dependency.  