### PR TITLE
Format timezone offset nicely

### DIFF
--- a/dozer/cogs/tba.py
+++ b/dozer/cogs/tba.py
@@ -108,7 +108,7 @@ class TBA(Cog):
 		current_second = currentTime.second
 		if current_second < 10:
 			current_second = "0{}".format(current_second)
-		await ctx.send("Timezone: {0} UTC{1} \nCurrent Time: {2}:{3}:{4} {5} ({6}:{3}:{4})".format(timezone["timeZoneName"], utc_offset, current_hour, current_minute, current_second, dayTime, current_hour_original)) 
+		await ctx.send("Timezone: {0} UTC{1:+g} \nCurrent Time: {2}:{3}:{4} {5} ({6}:{3}:{4})".format(timezone["timeZoneName"], utc_offset, current_hour, current_minute, current_second, dayTime, current_hour_original)) 
 					
 	timezone.example_usage = """
 	`{prefix}timezone 3572` - show the local time of team 3572, Wavelength


### PR DESCRIPTION
* Always display a sign, even for positive offsets.
* Don't show a trailing .0 if the offset is an integer number of hours.