### PR TITLE
General namegame updates and (big) bugfixes

### DIFF
--- a/dozer/cogs/namegame.py
+++ b/dozer/cogs/namegame.py
@@ -285,7 +285,7 @@ class NameGame(Cog):
 			with db.Session() as session:
 				config = session.query(NameGameConfig).filter_by(guild_id=ctx.guild.id).one_or_none()
 			mode = SUPPORTED_MODES[0] if config is None else config.mode
-			await ctx.send(f"Invalid game mode, assuming game mode `{mode}`. For a full list of game modes, run `{ctx.prefix}ng modes`")
+			await ctx.send(f"Unspecified or invalid game mode,  assuming game mode `{mode}`. For a full list of game modes, run `{ctx.prefix}ng modes`")
 
 		with db.Session() as session:
 			config = session.query(NameGameConfig).filter_by(guild_id=ctx.guild.id).one_or_none()

--- a/dozer/cogs/namegame.py
+++ b/dozer/cogs/namegame.py
@@ -253,7 +253,6 @@ class NameGame(Cog):
 	"""
 
 	@ng.command()
-	@has_permissions(manage_messages=True)
 	@game_is_running
 	async def unheck(self, ctx):
 		"""

--- a/dozer/cogs/namegame.py
+++ b/dozer/cogs/namegame.py
@@ -177,13 +177,13 @@ class NameGame(Cog):
 		game_embed.add_field(name="Times up!", value="You have 60 seconds to make a pick, or you get skipped and get a strike.")
 		game_embed.add_field(name="Shaking Things Up",value="Any team number that ends in a 0 mean that the next player has a wildcard, and can pick any legal team.")
 		game_embed.add_field(name="Pesky Commands", value=f"To start a game, type `{ctx.prefix}ng startround` and mention the players you want to play with. \
-				You can add people with `{ctx.prefix}ng addplayer`. \
-				When it's your turn, type `{ctx.prefix}ng pick <team> <teamname>` to execute your pick. \
-				If you need to skip, typing `{ctx.prefix}ng skip` gives you a strike and skips your turn. \
-				You can always do `{ctx.prefix}ng gameinfo` to get the current game status. \
-				If you ever need to quit, running `{ctx.prefix}ng drop` removes you from the game. \
-				For more detailed command help, run `{ctx.prefix}help ng.")
-		game_embed.add_field(name="Different Game Modes", value="You can play the name game with FTC teams too! To start a game playing with FTC teams, run `{ctx.prefix}ng startround ftc`")
+You can add people with `{ctx.prefix}ng addplayer <user_pings>`. \
+When it's your turn, type `{ctx.prefix}ng pick <team> <teamname>` to execute your pick. \
+If you need to skip, typing `{ctx.prefix}ng skip` gives you a strike and skips your turn. \
+You can always do `{ctx.prefix}ng gameinfo` to get the current game status. \
+If you ever need to quit, running `{ctx.prefix}ng drop` removes you from the game. \
+For more detailed command help, run `{ctx.prefix}help ng.`")
+		game_embed.add_field(name="Different Game Modes", value=f"You can play the name game with FTC teams too! To start a game playing with FTC teams, run `{ctx.prefix}ng startround ftc`")
 		await ctx.send(embed=game_embed)
 
 	info.example_usage = """

--- a/dozer/cogs/namegame.py
+++ b/dozer/cogs/namegame.py
@@ -330,6 +330,7 @@ class NameGame(Cog):
 
 		with await game.state_lock:
 			added = False
+			players = ctx.message.mentions or [ctx.author]
 			for player in ctx.message.mentions:
 				if player.bot:
 					await ctx.send(f"You can't invite bot users like {player.mention}!")


### PR DESCRIPTION
General updates and bugfixes for namegame:

* Added a new feature to ping people on their turn (which will not notify if the person is already watching the namegame chat), which can be enabled with `&ng config setpings true`
* Fixed the help text 
* Fixed a silly bug where player index incrementation failed to account for players being removed from the game, resulting in the game going off the rails with strange turn switches and soft-locks - resulting in travis's described IndexError
* Added a command, `&ng unheck`, that forcefully ends a game in case of softlocking
* Made `&ng addplayer` assume the current player is to be added if no arguments are specified
* `&ng startround` now works with player mentions without specifying a game mode


Dozer operators should run `sqlite3 dozer.db 'alter table namegame_config add column pings_enabled integer'` in the top-level dozer directory and restart their bots to fully apply changes if pulled.