### PR TITLE
Add username#discriminator to join and mentions to leave messages

### DIFF
--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -309,7 +309,7 @@ class Moderation(Cog):
 	async def on_member_join(self, member):
 		join = discord.Embed(type='rich', color=0x00FF00)
 		join.set_author(name = 'Member Joined', icon_url = member.avatar_url_as(format='png', size=32))
-		join.description = "+ {} ({})".format(member.mention, member.id)
+		join.description = "{0.mention}\n{0} ({0.id})".format(member)
 		join.set_footer(text="{} | {} members".format(member.guild.name, member.guild.member_count))
 		with db.Session() as session:
 			memberlogchannel = session.query(Guildmemberlog).filter_by(id=member.guild.id).one_or_none()
@@ -326,7 +326,7 @@ class Moderation(Cog):
 	async def on_member_remove(self, member):
 		leave = discord.Embed(type='rich', color=0xFF0000)
 		leave.set_author(name = 'Member Left', icon_url = member.avatar_url_as(format='png', size=32))
-		leave.description = "- {} ({})".format(member, member.id)
+		leave.description = "{0.mention}\n{0} ({0.id})".format(member)
 		leave.set_footer(text="{} | {} members".format(member.guild.name, member.guild.member_count))
 		with db.Session() as session:
 			memberlogchannel = session.query(Guildmemberlog).filter_by(id=member.guild.id).one_or_none()


### PR DESCRIPTION
Android doesn't render mentions in embeds. Including the username and discriminator will let Android users see who joined.  
The member's mention is also included in the leave log, since the mention will still be valid and useful for members that share another guild with the user who left.