### PR TITLE
Reformat everything to be much more pep8 compliant

### DIFF
--- a/dozer/__main__.py
+++ b/dozer/__main__.py
@@ -1,41 +1,44 @@
-import json, os.path, sys
+import json
+import os.path
+import sys
+
 from . import db
 
 config = {
-	'prefix': '&', 'developers': [],
-	'tba': {
-		'key': ''
-	},
-	'toa': {
-		'key': 'Put TOA API key here',
-		'app_name': 'Dozer',
-	},
-	'gmaps_key': "PUT GOOGLE MAPS API KEY HERE",
-	'discord_token': "Put Discord API Token here.",
-	'is_backup': False
+    'prefix': '&', 'developers': [],
+    'tba': {
+        'key': ''
+    },
+    'toa': {
+        'key': 'Put TOA API key here',
+        'app_name': 'Dozer',
+    },
+    'gmaps_key': "PUT GOOGLE MAPS API KEY HERE",
+    'discord_token': "Put Discord API Token here.",
+    'is_backup': False
 }
 config_file = 'config.json'
 
 if os.path.isfile(config_file):
-	with open(config_file) as f:
-		config.update(json.load(f))
+    with open(config_file) as f:
+        config.update(json.load(f))
 
 with open('config.json', 'w') as f:
-	json.dump(config, f, indent='\t')
+    json.dump(config, f, indent='\t')
 
 if 'discord_token' not in config:
-	sys.exit('Discord token must be supplied in configuration')
+    sys.exit('Discord token must be supplied in configuration')
 
 if sys.version_info < (3, 6):
-	sys.exit('Dozer requires Python 3.6 or higher to run. This is version %s.' % '.'.join(sys.version_info[:3]))
+    sys.exit('Dozer requires Python 3.6 or higher to run. This is version %s.' % '.'.join(sys.version_info[:3]))
 
-from . import Dozer # After version check
+from . import Dozer  # After version check
 
 bot = Dozer(config)
 
 for ext in os.listdir('dozer/cogs'):
-	if not ext.startswith(('_', '.')):
-		bot.load_extension('dozer.cogs.' + ext[:-3]) # Remove '.py'
+    if not ext.startswith(('_', '.')):
+        bot.load_extension('dozer.cogs.' + ext[:-3])  # Remove '.py'
 
 db.DatabaseObject.metadata.create_all()
 

--- a/dozer/bot.py
+++ b/dozer/bot.py
@@ -1,5 +1,10 @@
-import discord, re, traceback, logging, sys
+import discord
+import logging
+import re
+import sys
+import traceback
 from discord.ext import commands
+
 from . import utils
 
 logger = logging.Logger(name='dozer')
@@ -9,86 +14,102 @@ handler.level = logging.INFO
 logger.addHandler(handler)
 handler.setFormatter(fmt=logging.Formatter('[%(asctime)s] [%(levelname)s] [%(name)s] %(message)s'))
 
+
 class InvalidContext(commands.CheckFailure):
-	"""
-	Check failure raised by the global check for an invalid command context - executed by a bot, exceeding global rate-limit, etc.
-	The message will be ignored.
-	"""
+    """
+    Check failure raised by the global check for an invalid command context - executed by a bot, exceeding global rate-limit, etc.
+    The message will be ignored.
+    """
+
 
 class DozerContext(commands.Context):
-	async def send(self, content=None, **kwargs):
-		if content is not None:
-			content = utils.clean(self, content, mass=True, member=False, role=False, channel=False)
-		return await super().send(content, **kwargs)
+    async def send(self, content=None, **kwargs):
+        if content is not None:
+            content = utils.clean(self, content, mass=True, member=False, role=False, channel=False)
+        return await super().send(content, **kwargs)
+
 
 class Dozer(commands.Bot):
-	_global_cooldown = commands.Cooldown(1, 1, commands.BucketType.user) # One command per second per user
-	def __init__(self, config):
-		super().__init__(command_prefix=config['prefix'])
-		self.config = config
-		self.check(self.global_checks)
-	
-	async def on_ready(self):
-		logger.info('Signed in as {0!s} ({0.id})'.format(self.user))
-		if self.config['is_backup']:
-			status = discord.Status.dnd
-		else:
-			status = discord.Status.online
-		await self.change_presence(game=discord.Game(name='%shelp | %d guilds' % (self.config['prefix'], len(self.guilds))), status=status)
-	
-	async def get_context(self, message):
-		ctx = await super().get_context(message, cls=DozerContext)
-		return ctx
-	
-	async def on_command_error(self, ctx, err):
-		if isinstance(err, commands.NoPrivateMessage):
-			await ctx.send('{}, This command cannot be used in DMs.'.format(ctx.author.mention))
-		elif isinstance(err, commands.UserInputError):
-			await ctx.send('{}, {}'.format(ctx.author.mention, self.format_error(ctx, err)))
-		elif isinstance(err, commands.NotOwner):
-			await ctx.send('{}, {}'.format(ctx.author.mention, err.args[0]))
-		elif isinstance(err, commands.MissingPermissions):
-			permission_names = [name.replace('guild', 'server').replace('_', ' ').title() for name in err.missing_perms]
-			await ctx.send('{}, you need {} permissions to run this command!'.format(ctx.author.mention, utils.pretty_concat(permission_names)))
-		elif isinstance(err, commands.BotMissingPermissions):
-			permission_names = [name.replace('guild', 'server').replace('_', ' ').title() for name in err.missing_perms]
-			await ctx.send('{}, I need {} permissions to run this command!'.format(ctx.author.mention, utils.pretty_concat(permission_names)))
-		elif isinstance(err, commands.CommandOnCooldown):
-			await ctx.send('{}, That command is on cooldown! Try again in {:.2f}s!'.format(ctx.author.mention, err.retry_after))
-		elif isinstance(err, (commands.CommandNotFound, InvalidContext)):
-			pass # Silent ignore
-		else:
-			await ctx.send('```\n%s\n```' % ''.join(traceback.format_exception_only(type(err), err)).strip())
-			if isinstance(ctx.channel, discord.TextChannel):
-				logger.error('Error in command <{0}> ({1.name!r}({1.id}) {2}({2.id}) {3}({3.id}) {4!r})'.format(ctx.command, ctx.guild, ctx.channel, ctx.author, ctx.message.content))
-			else:
-				logger.error('Error in command <{0}> (DM {1}({1.id}) {2!r})'.format(ctx.command, ctx.channel.recipient, ctx.message.content))
-			logger.error(''.join(traceback.format_exception(type(err), err, err.__traceback__)))
-	
-	@staticmethod
-	def format_error(ctx, err, *, word_re=re.compile('[A-Z][a-z]+')):
-		type_words = word_re.findall(type(err).__name__)
-		type_msg = ' '.join(map(str.lower, type_words))
-		
-		if err.args:
-			return '%s: %s' % (type_msg, utils.clean(ctx, err.args[0]))
-		else:
-			return type_msg
-	
-	def global_checks(self, ctx):
-		if ctx.author.bot:
-			raise InvalidContext('Bots cannot run commands!')
-		retry_after = self._global_cooldown.update_rate_limit()
-		if retry_after:
-			raise InvalidContext('Global rate-limit exceeded!')
-		return True
-	
-	def run(self):
-		token = self.config['discord_token']
-		del self.config['discord_token'] # Prevent token dumping
-		super().run(token)
-	
-	async def shutdown(self):
-		await self.logout()
-		await self.close()
-		self.loop.stop()
+    _global_cooldown = commands.Cooldown(1, 1, commands.BucketType.user)  # One command per second per user
+
+    def __init__(self, config):
+        super().__init__(command_prefix=config['prefix'])
+        self.config = config
+        self.check(self.global_checks)
+
+    async def on_ready(self):
+        logger.info('Signed in as {0!s} ({0.id})'.format(self.user))
+        if self.config['is_backup']:
+            status = discord.Status.dnd
+        else:
+            status = discord.Status.online
+        await self.change_presence(
+            game=discord.Game(name='%shelp | %d guilds' % (self.config['prefix'], len(self.guilds))), status=status)
+
+    async def get_context(self, message):
+        ctx = await super().get_context(message, cls=DozerContext)
+        return ctx
+
+    async def on_command_error(self, ctx, err):
+        if isinstance(err, commands.NoPrivateMessage):
+            await ctx.send('{}, This command cannot be used in DMs.'.format(ctx.author.mention))
+        elif isinstance(err, commands.UserInputError):
+            await ctx.send('{}, {}'.format(ctx.author.mention, self.format_error(ctx, err)))
+        elif isinstance(err, commands.NotOwner):
+            await ctx.send('{}, {}'.format(ctx.author.mention, err.args[0]))
+        elif isinstance(err, commands.MissingPermissions):
+            permission_names = [name.replace('guild', 'server').replace('_', ' ').title() for name in err.missing_perms]
+            await ctx.send('{}, you need {} permissions to run this command!'.format(ctx.author.mention,
+                                                                                     utils.pretty_concat(
+                                                                                         permission_names)))
+        elif isinstance(err, commands.BotMissingPermissions):
+            permission_names = [name.replace('guild', 'server').replace('_', ' ').title() for name in err.missing_perms]
+            await ctx.send('{}, I need {} permissions to run this command!'.format(ctx.author.mention,
+                                                                                   utils.pretty_concat(
+                                                                                       permission_names)))
+        elif isinstance(err, commands.CommandOnCooldown):
+            await ctx.send(
+                '{}, That command is on cooldown! Try again in {:.2f}s!'.format(ctx.author.mention, err.retry_after))
+        elif isinstance(err, (commands.CommandNotFound, InvalidContext)):
+            pass  # Silent ignore
+        else:
+            await ctx.send('```\n%s\n```' % ''.join(traceback.format_exception_only(type(err), err)).strip())
+            if isinstance(ctx.channel, discord.TextChannel):
+                logger.error(
+                    'Error in command <{0}> ({1.name!r}({1.id}) {2}({2.id}) {3}({3.id}) {4!r})'.format(ctx.command,
+                                                                                                       ctx.guild,
+                                                                                                       ctx.channel,
+                                                                                                       ctx.author,
+                                                                                                       ctx.message.content))
+            else:
+                logger.error('Error in command <{0}> (DM {1}({1.id}) {2!r})'.format(ctx.command, ctx.channel.recipient,
+                                                                                    ctx.message.content))
+            logger.error(''.join(traceback.format_exception(type(err), err, err.__traceback__)))
+
+    @staticmethod
+    def format_error(ctx, err, *, word_re=re.compile('[A-Z][a-z]+')):
+        type_words = word_re.findall(type(err).__name__)
+        type_msg = ' '.join(map(str.lower, type_words))
+
+        if err.args:
+            return '%s: %s' % (type_msg, utils.clean(ctx, err.args[0]))
+        else:
+            return type_msg
+
+    def global_checks(self, ctx):
+        if ctx.author.bot:
+            raise InvalidContext('Bots cannot run commands!')
+        retry_after = self._global_cooldown.update_rate_limit()
+        if retry_after:
+            raise InvalidContext('Global rate-limit exceeded!')
+        return True
+
+    def run(self):
+        token = self.config['discord_token']
+        del self.config['discord_token']  # Prevent token dumping
+        super().run(token)
+
+    async def shutdown(self):
+        await self.logout()
+        await self.close()
+        self.loop.stop()

--- a/dozer/bot.py
+++ b/dozer/bot.py
@@ -59,14 +59,12 @@ class Dozer(commands.Bot):
             await ctx.send('{}, {}'.format(ctx.author.mention, err.args[0]))
         elif isinstance(err, commands.MissingPermissions):
             permission_names = [name.replace('guild', 'server').replace('_', ' ').title() for name in err.missing_perms]
-            await ctx.send('{}, you need {} permissions to run this command!'.format(ctx.author.mention,
-                                                                                     utils.pretty_concat(
-                                                                                         permission_names)))
+            await ctx.send('{}, you need {} permissions to run this command!'.format(
+                           ctx.author.mention, utils.pretty_concat(permission_names)))
         elif isinstance(err, commands.BotMissingPermissions):
             permission_names = [name.replace('guild', 'server').replace('_', ' ').title() for name in err.missing_perms]
-            await ctx.send('{}, I need {} permissions to run this command!'.format(ctx.author.mention,
-                                                                                   utils.pretty_concat(
-                                                                                       permission_names)))
+            await ctx.send('{}, I need {} permissions to run this command!'.format(
+                           ctx.author.mention, utils.pretty_concat(permission_names)))
         elif isinstance(err, commands.CommandOnCooldown):
             await ctx.send(
                 '{}, That command is on cooldown! Try again in {:.2f}s!'.format(ctx.author.mention, err.retry_after))
@@ -75,15 +73,11 @@ class Dozer(commands.Bot):
         else:
             await ctx.send('```\n%s\n```' % ''.join(traceback.format_exception_only(type(err), err)).strip())
             if isinstance(ctx.channel, discord.TextChannel):
-                logger.error(
-                    'Error in command <{0}> ({1.name!r}({1.id}) {2}({2.id}) {3}({3.id}) {4!r})'.format(ctx.command,
-                                                                                                       ctx.guild,
-                                                                                                       ctx.channel,
-                                                                                                       ctx.author,
-                                                                                                       ctx.message.content))
+                logger.error('Error in command <{0}> ({1.name!r}({1.id}) {2}({2.id}) {3}({3.id}) {4!r})'.format(
+                             ctx.command, ctx.guild, ctx.channel, ctx.author, ctx.message.content))
             else:
-                logger.error('Error in command <{0}> (DM {1}({1.id}) {2!r})'.format(ctx.command, ctx.channel.recipient,
-                                                                                    ctx.message.content))
+                logger.error('Error in command <{0}> (DM {1}({1.id}) {2!r})'.format(
+                             ctx.command, ctx.channel.recipient, ctx.message.content))
             logger.error(''.join(traceback.format_exception(type(err), err, err.__traceback__)))
 
     @staticmethod

--- a/dozer/cogs/_toa.py
+++ b/dozer/cogs/_toa.py
@@ -1,53 +1,59 @@
-import aiohttp
-import async_timeout
 import json
 from asyncio import sleep
 from datetime import datetime
 from urllib.parse import urljoin
 
+import aiohttp
+import async_timeout
+
 
 class TOAParser(object):
-	"""
-	A class to make async requests to The Orange Alliance.
-	"""
-	def __init__(self, api_key, aiohttp_session, base_url="https://theorangealliance.org/apiv2/", app_name="Dozer", ratelimit=True):
-		self.last_req = datetime.now()
-		self.ratelimit = ratelimit
-		self.base = base_url
-		self.http = aiohttp_session
-		self.headers = {
-			"X-Application-Origin": app_name,
-			"X-TOA-Key": api_key
-		}
+    """
+    A class to make async requests to The Orange Alliance.
+    """
 
-	async def req(self, endpoint):
-		"""Make an async request at the specified endpoint, waiting to let the ratelimit cool off."""
-		if self.ratelimit:
-			# this will delay a request to avoid the ratelimit
-			now = datetime.now()
-			diff = (now - self.last_req).total_seconds()
-			self.last_req = now
-			if diff < 2.2: # have a 200 ms fudge factor
-				await sleep(2.2 - diff)
-		tries = 0
-		while True:
-			try:
-				async with async_timeout.timeout(5) as _, self.http.get(urljoin(self.base, endpoint), headers=self.headers) as response:
-					res = TOAResponse()
-					# it seems sometimes toa forgets to return data as application/json and not text/html
-					data = json.loads(await response.text())
-					if data:
-						res._update(data[0])
-					else:
-						res.error = True
-					return res
-			except aiohttp.ClientError:
-				tries += 1	
-				if tries > 3:
-					raise
+    def __init__(self, api_key, aiohttp_session, base_url="https://theorangealliance.org/apiv2/", app_name="Dozer",
+                 ratelimit=True):
+        self.last_req = datetime.now()
+        self.ratelimit = ratelimit
+        self.base = base_url
+        self.http = aiohttp_session
+        self.headers = {
+            "X-Application-Origin": app_name,
+            "X-TOA-Key": api_key
+        }
+
+    async def req(self, endpoint):
+        """Make an async request at the specified endpoint, waiting to let the ratelimit cool off."""
+        if self.ratelimit:
+            # this will delay a request to avoid the ratelimit
+            now = datetime.now()
+            diff = (now - self.last_req).total_seconds()
+            self.last_req = now
+            if diff < 2.2:  # have a 200 ms fudge factor
+                await sleep(2.2 - diff)
+        tries = 0
+        while True:
+            try:
+                async with async_timeout.timeout(5) as _, self.http.get(urljoin(self.base, endpoint),
+                                                                        headers=self.headers) as response:
+                    res = TOAResponse()
+                    # it seems sometimes toa forgets to return data as application/json and not text/html
+                    data = json.loads(await response.text())
+                    if data:
+                        res._update(data[0])
+                    else:
+                        res.error = True
+                    return res
+            except aiohttp.ClientError:
+                tries += 1
+                if tries > 3:
+                    raise
+
 
 class TOAResponse(object):
-	def __init__(self):
-		self.error = False
-	def _update(self, v):
-		self.__dict__.update(v)
+    def __init__(self):
+        self.error = False
+
+    def _update(self, v):
+        self.__dict__.update(v)

--- a/dozer/cogs/_utils.py
+++ b/dozer/cogs/_utils.py
@@ -92,8 +92,7 @@ class Reactor:
             await self.message.add_reaction(emoji)
         while True:
             try:
-                reaction, reacting_member = await self.bot.wait_for('reaction_add', check=self._check_reaction,
-                                                                    timeout=self.timeout)
+                reaction, reacting_member = await self.bot.wait_for('reaction_add', check=self._check_reaction, timeout=self.timeout)
             except asyncio.TimeoutError:
                 break
 

--- a/dozer/cogs/_utils.py
+++ b/dozer/cogs/_utils.py
@@ -1,200 +1,217 @@
-import asyncio, inspect, itertools
+import asyncio
+import inspect
+
 from collections.abc import Mapping
 from discord.ext import commands
 
 __all__ = ['command', 'group', 'Cog', 'Reactor', 'Paginator', 'paginate', 'chunk']
 
+
 class CommandMixin:
-	_example_usage = None
-	@property
-	def example_usage(self):
-		return self._example_usage
-	
-	@example_usage.setter
-	def example_usage(self, usage):
-		self._example_usage = inspect.cleandoc(usage)
+    _example_usage = None
+
+    @property
+    def example_usage(self):
+        return self._example_usage
+
+    @example_usage.setter
+    def example_usage(self, usage):
+        self._example_usage = inspect.cleandoc(usage)
+
 
 class Command(commands.Command, CommandMixin):
-	pass
+    pass
+
 
 class Group(commands.Group, CommandMixin):
-	def command(self, **kwargs):
-		kwargs.setdefault('cls', Command)
-		return super(Group, self).command(**kwargs)
-	
-	def group(self, **kwargs):
-		kwargs.setdefault('cls', Group)
-		return super(Group, self).command(**kwargs)
+    def command(self, **kwargs):
+        kwargs.setdefault('cls', Command)
+        return super(Group, self).command(**kwargs)
+
+    def group(self, **kwargs):
+        kwargs.setdefault('cls', Group)
+        return super(Group, self).command(**kwargs)
+
 
 def command(**kwargs):
-	kwargs.setdefault('cls', Command)
-	return commands.command(**kwargs)
+    kwargs.setdefault('cls', Command)
+    return commands.command(**kwargs)
+
 
 def group(**kwargs):
-	kwargs.setdefault('cls', Group)
-	return commands.command(**kwargs)
+    kwargs.setdefault('cls', Group)
+    return commands.command(**kwargs)
+
 
 class Cog:
-	def __init__(self, bot):
-		self.bot = bot
+    def __init__(self, bot):
+        self.bot = bot
+
 
 class Reactor:
-	"""
-	A simple way to respond to Discord reactions.
-	Usage:
-		from ._utils import Reactor
-		# in a command
-		initial_reactions = [...] # Initial reactions (str or Emoji) to add
-		reactor = Reactor(ctx, initial_reactions) # Timeout is optional, and defaults to 1 minute
-		async for reaction in reactor:
-			# reaction is the str/Emoji that was added.
-			# reaction will not necessarily be in initial_reactions.
-			if reaction == this_emoji:
-				reactor.do(reactor.message.edit(content='This!')) # Any coroutine
-			elif reaction == that_emoji:
-				reactor.do(reactor.message.edit(content='That!'))
-			elif reaction == stop_emoji:
-				reactor.stop() # The next time around, the message will be deleted and the async-for will end
-			# If no action is set (e.g. unknown emoji), nothing happens
-	"""
-	_stop_reaction = object()
-	def __init__(self, ctx, initial_reactions, *, auto_remove=True, timeout=60):
-		"""
-		ctx: command context
-		initial_reactions: iterable of emoji to react with on start
-		auto_remove: if True, reactions are removed once processed
-		timeout: time, in seconds, to wait before stopping automatically. Set to None to wait forever.
-		"""
-		self.dest = ctx.channel
-		self.bot = ctx.bot
-		self.caller = ctx.author
-		self.me = ctx.me
-		self._reactions = tuple(initial_reactions)
-		self._remove_reactions = auto_remove and ctx.channel.permissions_for(ctx.me).manage_messages # Check for required permissions
-		self.timeout = timeout
-		self._action = None
-	
-	async def __aiter__(self):
-		self.message = await self.dest.send(embed=self.pages[self.page])
-		for emoji in self._reactions:
-			await self.message.add_reaction(emoji)
-		while True:
-			try:
-				reaction, reacting_member = await self.bot.wait_for('reaction_add', check=self._check_reaction, timeout=self.timeout)
-			except asyncio.TimeoutError:
-				break
-			
-			yield reaction.emoji
-			# Caller calls methods to set self._action; end of async for block, control resumes here
-			if self._remove_reactions:
-				await self.message.remove_reaction(reaction.emoji, reacting_member)
-			if self._action is self._stop_reaction:
-				break
-			elif self._action is None:
-				pass
-			else:
-				await self._action
-		for emoji in reversed(self._reactions):
-			await self.message.remove_reaction(emoji, self.me)
-	
-	def do(self, action):
-		self._action = action
-	
-	def stop(self):
-		self._action = self._stop_reaction
-	
-	def _check_reaction(self, reaction, member):
-		return reaction.message.id == self.message.id and member.id == self.caller.id
+    """
+    A simple way to respond to Discord reactions.
+    Usage:
+        from ._utils import Reactor
+        # in a command
+        initial_reactions = [...] # Initial reactions (str or Emoji) to add
+        reactor = Reactor(ctx, initial_reactions) # Timeout is optional, and defaults to 1 minute
+        async for reaction in reactor:
+            # reaction is the str/Emoji that was added.
+            # reaction will not necessarily be in initial_reactions.
+            if reaction == this_emoji:
+                reactor.do(reactor.message.edit(content='This!')) # Any coroutine
+            elif reaction == that_emoji:
+                reactor.do(reactor.message.edit(content='That!'))
+            elif reaction == stop_emoji:
+                reactor.stop() # The next time around, the message will be deleted and the async-for will end
+            # If no action is set (e.g. unknown emoji), nothing happens
+    """
+    _stop_reaction = object()
+
+    def __init__(self, ctx, initial_reactions, *, auto_remove=True, timeout=60):
+        """
+        ctx: command context
+        initial_reactions: iterable of emoji to react with on start
+        auto_remove: if True, reactions are removed once processed
+        timeout: time, in seconds, to wait before stopping automatically. Set to None to wait forever.
+        """
+        self.dest = ctx.channel
+        self.bot = ctx.bot
+        self.caller = ctx.author
+        self.me = ctx.me
+        self._reactions = tuple(initial_reactions)
+        self._remove_reactions = auto_remove and ctx.channel.permissions_for(
+            ctx.me).manage_messages  # Check for required permissions
+        self.timeout = timeout
+        self._action = None
+
+    async def __aiter__(self):
+        self.message = await self.dest.send(embed=self.pages[self.page])
+        for emoji in self._reactions:
+            await self.message.add_reaction(emoji)
+        while True:
+            try:
+                reaction, reacting_member = await self.bot.wait_for('reaction_add', check=self._check_reaction,
+                                                                    timeout=self.timeout)
+            except asyncio.TimeoutError:
+                break
+
+            yield reaction.emoji
+            # Caller calls methods to set self._action; end of async for block, control resumes here
+            if self._remove_reactions:
+                await self.message.remove_reaction(reaction.emoji, reacting_member)
+            if self._action is self._stop_reaction:
+                break
+            elif self._action is None:
+                pass
+            else:
+                await self._action
+        for emoji in reversed(self._reactions):
+            await self.message.remove_reaction(emoji, self.me)
+
+    def do(self, action):
+        self._action = action
+
+    def stop(self):
+        self._action = self._stop_reaction
+
+    def _check_reaction(self, reaction, member):
+        return reaction.message.id == self.message.id and member.id == self.caller.id
+
 
 class Paginator(Reactor):
-	"""
-	Extends functionality of Reactor for pagination.
-	Left- and right- arrow reactions are used to move between pages.
-	:stop: will stop the pagination.
-	Other reactions are given to the caller like normal.
-	Usage:
-		from ._utils import Reactor
-		# in a command
-		initial_reactions = [...] # Initial reactions (str or Emoji) to add (in addition to normal pagination reactions)
-		pages = [...] # Embeds to use for each page
-		paginator = Paginator(ctx, initial_reactions, pages)
-		async for reaction in paginator:
-			# See Reactor for how to handle reactions
-			# Paginator reactions will not be yielded here - only unknowns
-	"""
-	pagination_reactions = (
-		'\N{BLACK LEFT-POINTING DOUBLE TRIANGLE WITH VERTICAL BAR}', # :track_previous:
-		'\N{BLACK LEFT-POINTING TRIANGLE}', # :arrow_backward:
-		'\N{BLACK RIGHT-POINTING TRIANGLE}', # :arrow_forward:
-		'\N{BLACK RIGHT-POINTING DOUBLE TRIANGLE WITH VERTICAL BAR}', # :track_next:
-		'\N{BLACK SQUARE FOR STOP}' # :stop_button:
-	)
-	def __init__(self, ctx, initial_reactions, pages, *, start=0, auto_remove=True, timeout=60):
-		all_reactions = list(initial_reactions)
-		ind = all_reactions.index(Ellipsis)
-		all_reactions[ind:ind+1] = self.pagination_reactions
-		super().__init__(ctx, all_reactions, auto_remove=auto_remove, timeout=timeout)
-		if pages and isinstance(pages[-1], Mapping):
-			named_pages = pages.pop()
-			self.pages = dict(enumerate(pages), **named_pages)
-		else:
-			self.pages = pages
-		self.len_pages = len(pages)
-		self.page = start
-	
-	async def __aiter__(self):
-		self.reactor = super().__aiter__()
-		async for reaction in self.reactor:
-			try:
-				ind = self.pagination_reactions.index(reaction)
-			except ValueError: # Not in list - send to caller
-				yield reaction
-			else:
-				if ind == 0:
-					self.go_to_page(0)
-				elif ind == 1:
-					self.prev()
-				elif ind == 2:
-					self.next()
-				elif ind == 3:
-					self.go_to_page(-1)
-				else: # Only valid option left is 4
-					self.stop()
-	
-	def go_to_page(self, page):
-		if isinstance(page, int):
-			page = page % self.len_pages
-			if page < 0:
-				page += self.len_pages
-		self.page = page
-		self.do(self.message.edit(embed=self.pages[self.page]))
-	
-	def next(self, amt=1):
-		if isinstance(self.page, int):
-			self.go_to_page(self.page + amt)
-		else:
-			self.go_to_page(amt-1)
-	
-	def prev(self, amt=1):
-		if isinstance(self.page, int):
-			self.go_to_page(self.page - amt)
-		else:
-			self.go_to_page(-amt)
+    """
+    Extends functionality of Reactor for pagination.
+    Left- and right- arrow reactions are used to move between pages.
+    :stop: will stop the pagination.
+    Other reactions are given to the caller like normal.
+    Usage:
+        from ._utils import Reactor
+        # in a command
+        initial_reactions = [...] # Initial reactions (str or Emoji) to add (in addition to normal pagination reactions)
+        pages = [...] # Embeds to use for each page
+        paginator = Paginator(ctx, initial_reactions, pages)
+        async for reaction in paginator:
+            # See Reactor for how to handle reactions
+            # Paginator reactions will not be yielded here - only unknowns
+    """
+    pagination_reactions = (
+        '\N{BLACK LEFT-POINTING DOUBLE TRIANGLE WITH VERTICAL BAR}',  # :track_previous:
+        '\N{BLACK LEFT-POINTING TRIANGLE}',  # :arrow_backward:
+        '\N{BLACK RIGHT-POINTING TRIANGLE}',  # :arrow_forward:
+        '\N{BLACK RIGHT-POINTING DOUBLE TRIANGLE WITH VERTICAL BAR}',  # :track_next:
+        '\N{BLACK SQUARE FOR STOP}'  # :stop_button:
+    )
+
+    def __init__(self, ctx, initial_reactions, pages, *, start=0, auto_remove=True, timeout=60):
+        all_reactions = list(initial_reactions)
+        ind = all_reactions.index(Ellipsis)
+        all_reactions[ind:ind + 1] = self.pagination_reactions
+        super().__init__(ctx, all_reactions, auto_remove=auto_remove, timeout=timeout)
+        if pages and isinstance(pages[-1], Mapping):
+            named_pages = pages.pop()
+            self.pages = dict(enumerate(pages), **named_pages)
+        else:
+            self.pages = pages
+        self.len_pages = len(pages)
+        self.page = start
+
+    async def __aiter__(self):
+        self.reactor = super().__aiter__()
+        async for reaction in self.reactor:
+            try:
+                ind = self.pagination_reactions.index(reaction)
+            except ValueError:  # Not in list - send to caller
+                yield reaction
+            else:
+                if ind == 0:
+                    self.go_to_page(0)
+                elif ind == 1:
+                    self.prev()
+                elif ind == 2:
+                    self.next()
+                elif ind == 3:
+                    self.go_to_page(-1)
+                else:  # Only valid option left is 4
+                    self.stop()
+
+    def go_to_page(self, page):
+        if isinstance(page, int):
+            page = page % self.len_pages
+            if page < 0:
+                page += self.len_pages
+        self.page = page
+        self.do(self.message.edit(embed=self.pages[self.page]))
+
+    def next(self, amt=1):
+        if isinstance(self.page, int):
+            self.go_to_page(self.page + amt)
+        else:
+            self.go_to_page(amt - 1)
+
+    def prev(self, amt=1):
+        if isinstance(self.page, int):
+            self.go_to_page(self.page - amt)
+        else:
+            self.go_to_page(-amt)
+
 
 async def paginate(ctx, pages, *, start=0, auto_remove=True, timeout=60):
-	"""
-	Simple pagination based on Paginator. Pagination is handled normally and other reactions are ignored.
-	"""
-	paginator = Paginator(ctx, (...,), pages, start=start, auto_remove=auto_remove, timeout=timeout)
-	async for reaction in paginator:
-		pass # The normal pagination reactions are handled - just drop anything else
+    """
+    Simple pagination based on Paginator. Pagination is handled normally and other reactions are ignored.
+    """
+    paginator = Paginator(ctx, (...,), pages, start=start, auto_remove=auto_remove, timeout=timeout)
+    async for reaction in paginator:
+        pass  # The normal pagination reactions are handled - just drop anything else
+
 
 def chunk(iterable, size):
-	"""
-	Break an iterable into chunks of a fixed size. Returns an iterable of iterables.
-	Almost-inverse of itertools.chain.from_iterable - passing the output of this into that function will reconstruct the original iterable.
-	If the last chunk is not the full length, it will be returned but not padded.
-	"""
-	contents = list(iterable)
-	for i in range(0, len(contents), size):
-		yield contents[i:i+size]
+    """
+    Break an iterable into chunks of a fixed size. Returns an iterable of iterables.
+    Almost-inverse of itertools.chain.from_iterable - passing the output of this into that function will reconstruct the original iterable.
+    If the last chunk is not the full length, it will be returned but not padded.
+    """
+    contents = list(iterable)
+    for i in range(0, len(contents), size):
+        yield contents[i:i + size]

--- a/dozer/cogs/development.py
+++ b/dozer/cogs/development.py
@@ -1,99 +1,109 @@
-import copy, discord, importlib, re
+import copy
+import re
+import discord
+
 from discord.ext.commands import NotOwner
+
 from ._utils import *
 
-class Development(Cog):
-	"""
-	Commands useful for developing the bot.
-	These commands are restricted to bot developers.
-	"""
-	eval_globals = {}
-	for module in ('asyncio', 'collections', 'discord', 'inspect', 'itertools'):
-		eval_globals[module] = __import__(module)
-	eval_globals['__builtins__'] = __import__('builtins')
-	
-	def __local_check(self, ctx): # All of this cog is only available to devs
-		if ctx.author.id not in ctx.bot.config['developers']:
-			raise NotOwner('you are not a developer!')
-		return True
 
-	@command()
-	async def reload(self, ctx, cog):
-		"""Reloads a cog."""
-		extension = 'dozer.cogs.' + cog
-		msg = await ctx.send('Reloading extension %s' % extension)
-		self.bot.unload_extension(extension)
-		self.bot.load_extension(extension)
-		await msg.edit(content='Reloaded extension %s' % extension)
-	
-	reload.example_usage = """
+class Development(Cog):
+    """
+    Commands useful for developing the bot.
+    These commands are restricted to bot developers.
+    """
+    eval_globals = {}
+    for module in ('asyncio', 'collections', 'discord', 'inspect', 'itertools'):
+        eval_globals[module] = __import__(module)
+    eval_globals['__builtins__'] = __import__('builtins')
+
+    def __local_check(self, ctx):  # All of this cog is only available to devs
+        if ctx.author.id not in ctx.bot.config['developers']:
+            raise NotOwner('you are not a developer!')
+        return True
+
+    @command()
+    async def reload(self, ctx, cog):
+        """Reloads a cog."""
+        extension = 'dozer.cogs.' + cog
+        msg = await ctx.send('Reloading extension %s' % extension)
+        self.bot.unload_extension(extension)
+        self.bot.load_extension(extension)
+        await msg.edit(content='Reloaded extension %s' % extension)
+
+    reload.example_usage = """
 	`{prefix}reload development` - reloads the development cog
 	"""
-	
-	@command(name='eval')
-	async def evaluate(self, ctx, *, code):
-		"""
-		Evaluates Python.
-		Await is valid and `{ctx}` is the command context.
-		"""
-		if code.startswith('```'): code = code.strip('```').partition('\n')[2].strip() # Remove multiline code blocks
-		else: code = code.strip('`').strip() # Remove single-line code blocks, if necessary
-		
-		e = discord.Embed(type='rich')
-		e.add_field(name='Code', value='```py\n%s\n```' % code, inline=False)
-		try:
-			locals_ = locals()
-			load_function(code, self.eval_globals, locals_)
-			ret = await locals_['evaluated_function'](ctx)
-			
-			e.title = 'Python Evaluation - Success'
-			e.color = 0x00FF00
-			e.add_field(name='Output', value='```\n%s (%s)\n```' % (repr(ret), type(ret).__name__), inline=False)
-		except Exception as err:
-			e.title = 'Python Evaluation - Error'
-			e.color = 0xFF0000
-			e.add_field(name='Error', value='```\n%s\n```' % repr(err))
-		await ctx.send(embed=e)
-	
-	evaluate.example_usage = """
+
+    @command(name='eval')
+    async def evaluate(self, ctx, *, code):
+        """
+        Evaluates Python.
+        Await is valid and `{ctx}` is the command context.
+        """
+        if code.startswith('```'):
+            code = code.strip('```').partition('\n')[2].strip()  # Remove multiline code blocks
+        else:
+            code = code.strip('`').strip()  # Remove single-line code blocks, if necessary
+
+        e = discord.Embed(type='rich')
+        e.add_field(name='Code', value='```py\n%s\n```' % code, inline=False)
+        try:
+            locals_ = locals()
+            load_function(code, self.eval_globals, locals_)
+            ret = await locals_['evaluated_function'](ctx)
+
+            e.title = 'Python Evaluation - Success'
+            e.color = 0x00FF00
+            e.add_field(name='Output', value='```\n%s (%s)\n```' % (repr(ret), type(ret).__name__), inline=False)
+        except Exception as err:
+            e.title = 'Python Evaluation - Error'
+            e.color = 0xFF0000
+            e.add_field(name='Error', value='```\n%s\n```' % repr(err))
+        await ctx.send(embed=e)
+
+    evaluate.example_usage = """
 	`{prefix}eval 0.1 + 0.2` - calculates 0.1 + 0.2
 	`{prefix}eval await ctx.send('Hello world!')` - send "Hello World!" to this channel
 	"""
-	
-	@command(name='su', pass_context=True)
-	async def pseudo(self, ctx, user : discord.Member, *, command):
-		"""Execute a command as another user."""
-		msg = copy.copy(ctx.message)
-		msg.author = user
-		msg.content = command
-		context = await self.bot.get_context(msg)
-		return await self.bot.invoke(context)
-	
-	pseudo.example_usage = """
+
+    @command(name='su', pass_context=True)
+    async def pseudo(self, ctx, user: discord.Member, *, command):
+        """Execute a command as another user."""
+        msg = copy.copy(ctx.message)
+        msg.author = user
+        msg.content = command
+        context = await self.bot.get_context(msg)
+        return await self.bot.invoke(context)
+
+    pseudo.example_usage = """
 	`{prefix}su cooldude#1234 {prefix}ping` - simulate cooldude sending `{prefix}ping`
 	"""
 
+
 def load_function(code, globals_, locals_):
-	function_header = 'async def evaluated_function(ctx):'
-	
-	lines = code.splitlines()
-	if len(lines) > 1:
-		indent = 4
-		for line in lines:
-			line_indent = re.search(r'\S', line).start() # First non-WS character is length of indent
-			if line_indent:
-				indent = line_indent
-				break
-		line_sep = '\n' + ' ' * indent
-		exec(function_header + line_sep + line_sep.join(lines), globals_, locals_)
-	else:
-		try:
-			exec(function_header + '\n\treturn ' + lines[0], globals_, locals_)
-		except SyntaxError as err: # Either adding the 'return' caused an error, or it's user error
-			if err.text[err.offset-1] == '=' or err.text[err.offset-3:err.offset] == 'del' or err.text[err.offset-6:err.offset] == 'return': # return-caused error
-				exec(function_header + '\n\t' + lines[0], globals_, locals_)
-			else: # user error
-				raise err
+    function_header = 'async def evaluated_function(ctx):'
+
+    lines = code.splitlines()
+    if len(lines) > 1:
+        indent = 4
+        for line in lines:
+            line_indent = re.search(r'\S', line).start()  # First non-WS character is length of indent
+            if line_indent:
+                indent = line_indent
+                break
+        line_sep = '\n' + ' ' * indent
+        exec(function_header + line_sep + line_sep.join(lines), globals_, locals_)
+    else:
+        try:
+            exec(function_header + '\n\treturn ' + lines[0], globals_, locals_)
+        except SyntaxError as err:  # Either adding the 'return' caused an error, or it's user error
+            if err.text[err.offset - 1] == '=' or err.text[err.offset - 3:err.offset] == 'del' or err.text[
+                                                                                                  err.offset - 6:err.offset] == 'return':  # return-caused error
+                exec(function_header + '\n\t' + lines[0], globals_, locals_)
+            else:  # user error
+                raise err
+
 
 def setup(bot):
-	bot.add_cog(Development(bot))
+    bot.add_cog(Development(bot))

--- a/dozer/cogs/development.py
+++ b/dozer/cogs/development.py
@@ -32,8 +32,8 @@ class Development(Cog):
         await msg.edit(content='Reloaded extension %s' % extension)
 
     reload.example_usage = """
-	`{prefix}reload development` - reloads the development cog
-	"""
+    `{prefix}reload development` - reloads the development cog
+    """
 
     @command(name='eval')
     async def evaluate(self, ctx, *, code):
@@ -63,9 +63,9 @@ class Development(Cog):
         await ctx.send(embed=e)
 
     evaluate.example_usage = """
-	`{prefix}eval 0.1 + 0.2` - calculates 0.1 + 0.2
-	`{prefix}eval await ctx.send('Hello world!')` - send "Hello World!" to this channel
-	"""
+    `{prefix}eval 0.1 + 0.2` - calculates 0.1 + 0.2
+    `{prefix}eval await ctx.send('Hello world!')` - send "Hello World!" to this channel
+    """
 
     @command(name='su', pass_context=True)
     async def pseudo(self, ctx, user: discord.Member, *, command):
@@ -77,8 +77,8 @@ class Development(Cog):
         return await self.bot.invoke(context)
 
     pseudo.example_usage = """
-	`{prefix}su cooldude#1234 {prefix}ping` - simulate cooldude sending `{prefix}ping`
-	"""
+    `{prefix}su cooldude#1234 {prefix}ping` - simulate cooldude sending `{prefix}ping`
+    """
 
 
 def load_function(code, globals_, locals_):

--- a/dozer/cogs/fun.py
+++ b/dozer/cogs/fun.py
@@ -1,62 +1,64 @@
-from discord.ext.commands import has_permissions, bot_has_permissions
-from ._utils import *
-from asyncio import sleep
-import discord
 import random
+from asyncio import sleep
+
+import discord
+
+from ._utils import *
+
 
 class Fun(Cog):
 
-	@command()
-	async def fight(self, ctx, opponent : discord.Member):
-		"""Start a fight with another user."""
-		responses = [
-			"was hit on the head by",
-			"was kicked by",
-			"was slammed into a wall by",
-			"was dropkicked by",
-			"was DDoSed by",
-			"was chokeslammed by",
-			"was run over with a robot by",
-			"had their IQ dropped 15 points by",
-			"had a heavy object dropped on them by",
-			"was beat up by"
-		]
-		
-		damages = [100, 150, 200, 300, 50, 250, 420]
-		players = [ctx.author, opponent]
-		hps = [1000, 1000]
-		turn = random.randint(0, 1)
-		
-		messages = []
-		while hps[0] > 0 and hps[1] > 0:
-			opp_idx = (turn + 1) % 2
-			damage = random.choice(damages)
-			hps[opp_idx] = max(hps[opp_idx] - damage, 0)
-			messages.append(await ctx.send("**{opponent}** {response} **{attacker}**! *[-{dmg} hp] [{hp} HP remaining]*".format(
-				opponent=players[opp_idx].name,
-				attacker=players[turn].name,
-				response=random.choice(responses),
-				dmg=damage,
-				hp=hps[opp_idx]
-			)))
-			await sleep(1.5)
-			turn = opp_idx
-		await ctx.send("{loser} lost! GG {winner}!".format(loser=players[turn].mention, winner=players[(turn + 1) % 2].mention))
-		await sleep(5)
-		# bulk delete if we have the manage messages permission
-		if ctx.channel.permissions_for(ctx.me).manage_messages:
-			await ctx.channel.delete_messages(messages)
-		else:
-			# otherwise delete manually
-			for msg in messages:
-				await msg.delete()
+    @command()
+    async def fight(self, ctx, opponent: discord.Member):
+        """Start a fight with another user."""
+        responses = [
+            "was hit on the head by",
+            "was kicked by",
+            "was slammed into a wall by",
+            "was dropkicked by",
+            "was DDoSed by",
+            "was chokeslammed by",
+            "was run over with a robot by",
+            "had their IQ dropped 15 points by",
+            "had a heavy object dropped on them by",
+            "was beat up by"
+        ]
 
+        damages = [100, 150, 200, 300, 50, 250, 420]
+        players = [ctx.author, opponent]
+        hps = [1000, 1000]
+        turn = random.randint(0, 1)
 
+        messages = []
+        while hps[0] > 0 and hps[1] > 0:
+            opp_idx = (turn + 1) % 2
+            damage = random.choice(damages)
+            hps[opp_idx] = max(hps[opp_idx] - damage, 0)
+            messages.append(
+                await ctx.send("**{opponent}** {response} **{attacker}**! *[-{dmg} hp] [{hp} HP remaining]*".format(
+                    opponent=players[opp_idx].name,
+                    attacker=players[turn].name,
+                    response=random.choice(responses),
+                    dmg=damage,
+                    hp=hps[opp_idx]
+                )))
+            await sleep(1.5)
+            turn = opp_idx
+        await ctx.send(
+            "{loser} lost! GG {winner}!".format(loser=players[turn].mention, winner=players[(turn + 1) % 2].mention))
+        await sleep(5)
+        # bulk delete if we have the manage messages permission
+        if ctx.channel.permissions_for(ctx.me).manage_messages:
+            await ctx.channel.delete_messages(messages)
+        else:
+            # otherwise delete manually
+            for msg in messages:
+                await msg.delete()
 
-				
-	fight.example_usage = """
+    fight.example_usage = """
 	`{prefix}fight @user2#2322 - Initiates a fight with @user2#2322`
 	"""
 
+
 def setup(bot):
-	bot.add_cog(Fun(bot))
+    bot.add_cog(Fun(bot))

--- a/dozer/cogs/fun.py
+++ b/dozer/cogs/fun.py
@@ -56,8 +56,8 @@ class Fun(Cog):
                 await msg.delete()
 
     fight.example_usage = """
-	`{prefix}fight @user2#2322 - Initiates a fight with @user2#2322`
-	"""
+    `{prefix}fight @user2#2322 - Initiates a fight with @user2#2322`
+    """
 
 
 def setup(bot):

--- a/dozer/cogs/general.py
+++ b/dozer/cogs/general.py
@@ -22,8 +22,8 @@ class General(Cog):
             content=response.content + '\nTook %d ms to respond.' % (delay.seconds * 1000 + delay.microseconds // 1000))
 
     ping.example_usage = """
-	`{prefix}ping` - Calculate and display the bot's response time
-	"""
+    `{prefix}ping` - Calculate and display the bot's response time
+    """
 
     @cooldown(1, 10, BucketType.channel)
     @command(name='help', aliases=['about'])
@@ -51,10 +51,10 @@ class General(Cog):
                 await self._help_command(ctx, command)
 
     base_help.example_usage = """
-	`{prefix}help` - General help message
-	`{prefix}help help` - Help about the help command
-	`{prefix}help General` - Help about the General category
-	"""
+    `{prefix}help` - General help message
+    `{prefix}help help` - Help about the help command
+    `{prefix}help General` - Help about the General category
+    """
 
     async def _help_all(self, ctx):
         """Gets the help message for all commands."""
@@ -64,9 +64,9 @@ class General(Cog):
         info.add_field(name='About',
                        value="Dozer: A collaborative bot for FIRST Discord servers, developed by the FRC Discord Server Development Team")
         info.add_field(name='About `{}{}`'.format(ctx.prefix, ctx.invoked_with), value=inspect.cleandoc("""
-		This command can show info for all commands, a specific command, or a category of commands.
-		Use `{0}{1} {1}` for more information.
-		""".format(ctx.prefix, ctx.invoked_with)), inline=False)
+        This command can show info for all commands, a specific command, or a category of commands.
+        Use `{0}{1} {1}` for more information.
+        """.format(ctx.prefix, ctx.invoked_with)), inline=False)
         info.add_field(name='Support',
                        value="Join our development server at https://discord.gg/bB8tcQ8 for support, to help with development, or if you have any questions or comments!")
         info.add_field(name="Open Source",
@@ -180,9 +180,9 @@ class General(Cog):
                 await ctx.send(text)
 
     invites.example_usage = """
-	`{prefix}invtes 5` - Generates 5 single use invites.
-	`{prefix}invites 2 12` Generates 2 single use invites that last for 12 hours.
-	"""
+    `{prefix}invtes 5` - Generates 5 single use invites.
+    `{prefix}invites 2 12` Generates 2 single use invites that last for 12 hours.
+    """
 
     @command()
     @has_permissions(administrator=True)
@@ -203,8 +203,8 @@ class General(Cog):
         await ctx.send("Welcome channel set to {}".format(welcome_channel.mention))
 
     welcomeconfig.example_usage = """
-	`{prefix}welcomeconfig #new-members` - Sets the invite channel to #new-members.
-	"""
+    `{prefix}welcomeconfig #new-members` - Sets the invite channel to #new-members.
+    """
 
 
 def setup(bot):

--- a/dozer/cogs/general.py
+++ b/dozer/cogs/general.py
@@ -1,194 +1,218 @@
-import discord, inspect
+import discord
+import inspect
 from discord.ext.commands import BadArgument, bot_has_permissions, cooldown, BucketType, Group, has_permissions
+
 from ._utils import *
 from .. import db
 
-class General(Cog):
-	"""General commands common to all Discord bots."""
-	@command()
-	async def ping(self, ctx):
-		"""Check the bot is online, and calculate its response time."""
-		if ctx.guild is None:
-			location = 'DMs'
-		else:
-			location = 'the **%s** server' % ctx.guild.name
-		response = await ctx.send('Pong! We\'re in %s.' % location)
-		delay = response.created_at - ctx.message.created_at
-		await response.edit(content=response.content + '\nTook %d ms to respond.' % (delay.seconds * 1000 + delay.microseconds // 1000))
 
-	
-	ping.example_usage = """
+class General(Cog):
+    """General commands common to all Discord bots."""
+
+    @command()
+    async def ping(self, ctx):
+        """Check the bot is online, and calculate its response time."""
+        if ctx.guild is None:
+            location = 'DMs'
+        else:
+            location = 'the **%s** server' % ctx.guild.name
+        response = await ctx.send('Pong! We\'re in %s.' % location)
+        delay = response.created_at - ctx.message.created_at
+        await response.edit(
+            content=response.content + '\nTook %d ms to respond.' % (delay.seconds * 1000 + delay.microseconds // 1000))
+
+    ping.example_usage = """
 	`{prefix}ping` - Calculate and display the bot's response time
 	"""
-	
-	@cooldown(1, 10, BucketType.channel)
-	@command(name='help', aliases=['about'])
-	@bot_has_permissions(add_reactions=True, embed_links=True, read_message_history=True) # Message history is for internals of paginate()
-	async def base_help(self, ctx, *target):
-		"""Show this message."""
-		if not target: # No commands - general help
-			await self._help_all(ctx)
-		elif len(target) == 1: # Cog or command
-			target_name = target[0]
-			if target_name in ctx.bot.cogs:
-				await self._help_cog(ctx, ctx.bot.cogs[target_name])
-			else:
-				command = ctx.bot.get_command(target_name)
-				if command is None:
-					raise BadArgument('that command/cog does not exist!')
-				else:
-					await self._help_command(ctx, command)
-		else: # Command with subcommand
-			command = ctx.bot.get_command(' '.join(target))
-			if command is None:
-				raise BadArgument('that command does not exist!')
-			else:
-				await self._help_command(ctx, command)
-	
-	base_help.example_usage = """
+
+    @cooldown(1, 10, BucketType.channel)
+    @command(name='help', aliases=['about'])
+    @bot_has_permissions(add_reactions=True, embed_links=True,
+                         read_message_history=True)  # Message history is for internals of paginate()
+    async def base_help(self, ctx, *target):
+        """Show this message."""
+        if not target:  # No commands - general help
+            await self._help_all(ctx)
+        elif len(target) == 1:  # Cog or command
+            target_name = target[0]
+            if target_name in ctx.bot.cogs:
+                await self._help_cog(ctx, ctx.bot.cogs[target_name])
+            else:
+                command = ctx.bot.get_command(target_name)
+                if command is None:
+                    raise BadArgument('that command/cog does not exist!')
+                else:
+                    await self._help_command(ctx, command)
+        else:  # Command with subcommand
+            command = ctx.bot.get_command(' '.join(target))
+            if command is None:
+                raise BadArgument('that command does not exist!')
+            else:
+                await self._help_command(ctx, command)
+
+    base_help.example_usage = """
 	`{prefix}help` - General help message
 	`{prefix}help help` - Help about the help command
 	`{prefix}help General` - Help about the General category
 	"""
-	
-	async def _help_all(self, ctx):
-		"""Gets the help message for all commands."""
-		info = discord.Embed(title='Dozer: Info', description='A guild management bot for FIRST Discord servers', color=discord.Color.blue())
-		info.set_thumbnail(url=self.bot.user.avatar_url)
-		info.add_field(name='About', value="Dozer: A collaborative bot for FIRST Discord servers, developed by the FRC Discord Server Development Team")
-		info.add_field(name='About `{}{}`'.format(ctx.prefix, ctx.invoked_with), value=inspect.cleandoc("""
+
+    async def _help_all(self, ctx):
+        """Gets the help message for all commands."""
+        info = discord.Embed(title='Dozer: Info', description='A guild management bot for FIRST Discord servers',
+                             color=discord.Color.blue())
+        info.set_thumbnail(url=self.bot.user.avatar_url)
+        info.add_field(name='About',
+                       value="Dozer: A collaborative bot for FIRST Discord servers, developed by the FRC Discord Server Development Team")
+        info.add_field(name='About `{}{}`'.format(ctx.prefix, ctx.invoked_with), value=inspect.cleandoc("""
 		This command can show info for all commands, a specific command, or a category of commands.
 		Use `{0}{1} {1}` for more information.
 		""".format(ctx.prefix, ctx.invoked_with)), inline=False)
-		info.add_field(name='Support', value="Join our development server at https://discord.gg/bB8tcQ8 for support, to help with development, or if you have any questions or comments!")
-		info.add_field(name="Open Source", value="Dozer is open source! Feel free to view and contribute to our Python code [on Github](https://github.com/FRCDiscord/Dozer)")
-		info.set_footer(text='Dozer Help | all commands | Info page')
-		await self._show_help(ctx, info, 'Dozer: Commands', '', 'all commands', ctx.bot.commands)
-	
-	async def _help_command(self, ctx, command):
-		"""Gets the help message for one command."""
-		info = discord.Embed(title='Command: {}{}'.format(ctx.prefix, command.signature), description=command.help or (None if command.example_usage else 'No information provided.'), color=discord.Color.blue())
-		usage = command.example_usage
-		if usage is not None:
-			info.add_field(name='Usage', value=usage.format(prefix=ctx.prefix, name=ctx.invoked_with), inline=False)
-		info.set_footer(text='Dozer Help | {!r} command | Info'.format(command.qualified_name))
-		await self._show_help(ctx, info, 'Subcommands: {prefix}{signature}', '', '{command.qualified_name!r} command', command.commands if isinstance(command, Group) else set(), command=command, signature=command.signature)
-	
-	async def _help_cog(self, ctx, cog):
-		"""Gets the help message for one cog."""
-		await self._show_help(ctx, None, 'Category: {cog_name}', inspect.cleandoc(cog.__doc__ or ''), '{cog_name!r} category', (command for command in ctx.bot.commands if command.instance is cog), cog_name=type(cog).__name__)
-	
-	async def _show_help(self, ctx, start_page, title, description, footer, commands, **format_args):
-		"""Creates and sends a template help message, with arguments filled in."""
-		format_args['prefix'] = ctx.prefix
-		footer = 'Dozer Help | {} | Page {}'.format(footer, '{page_num} of {len_pages}') # Page info is inserted as a parameter so page_num and len_pages aren't evaluated now
-		if commands:
-			command_chunks = list(chunk(sorted(commands, key=lambda cmd: cmd.name), 4))
-			format_args['len_pages'] = len(command_chunks)
-			pages = []
-			for page_num, page_commands in enumerate(command_chunks):
-				format_args['page_num'] = page_num + 1
-				page = discord.Embed(title=title.format(**format_args), description=description.format(**format_args), color=discord.Color.blue())
-				for command in page_commands:
-					if command.short_doc:
-						embed_value = command.short_doc
-					elif command.example_usage: # Usage provided - show the user the command to see it
-						embed_value = 'Use `{0.prefix}{0.invoked_with} {1.qualified_name}` for more information.'.format(ctx, command)
-					else:
-						embed_value = 'No information provided.'
-					page.add_field(name=ctx.prefix + command.signature, value=embed_value, inline=False)
-				page.set_footer(text=footer.format(**format_args))
-				pages.append(page)
-			
-			if start_page is not None:
-				pages.append({'info': start_page})
-			
-			if len(pages) == 1:
-				await ctx.send(embed=pages[0])
-			elif start_page is not None:
-				info_emoji = '\N{INFORMATION SOURCE}'
-				p = Paginator(ctx, (info_emoji, ...), pages, start='info', auto_remove=ctx.channel.permissions_for(ctx.me))
-				async for reaction in p:
-					if reaction == info_emoji:
-						p.go_to_page('info')
-			else:
-				await paginate(ctx, pages, auto_remove=ctx.channel.permissions_for(ctx.me))
-		elif start_page: # No commands - command without subcommands or empty cog - but a usable info page
-			await ctx.send(embed=start_page)
-		else: # No commands, and no info page
-			format_args['len_pages'] = 1
-			format_args['page_num'] = 1
-			embed = discord.Embed(title=title.format(**format_args), description=description.format(**format_args), color=discord.Color.blue())
-			embed.set_footer(text=footer.format(**format_args))
-			await ctx.send(embed=embed)
+        info.add_field(name='Support',
+                       value="Join our development server at https://discord.gg/bB8tcQ8 for support, to help with development, or if you have any questions or comments!")
+        info.add_field(name="Open Source",
+                       value="Dozer is open source! Feel free to view and contribute to our Python code [on Github](https://github.com/FRCDiscord/Dozer)")
+        info.set_footer(text='Dozer Help | all commands | Info page')
+        await self._show_help(ctx, info, 'Dozer: Commands', '', 'all commands', ctx.bot.commands)
 
+    async def _help_command(self, ctx, command):
+        """Gets the help message for one command."""
+        info = discord.Embed(title='Command: {}{}'.format(ctx.prefix, command.signature), description=command.help or (
+            None if command.example_usage else 'No information provided.'), color=discord.Color.blue())
+        usage = command.example_usage
+        if usage is not None:
+            info.add_field(name='Usage', value=usage.format(prefix=ctx.prefix, name=ctx.invoked_with), inline=False)
+        info.set_footer(text='Dozer Help | {!r} command | Info'.format(command.qualified_name))
+        await self._show_help(ctx, info, 'Subcommands: {prefix}{signature}', '', '{command.qualified_name!r} command',
+                              command.commands if isinstance(command, Group) else set(), command=command,
+                              signature=command.signature)
 
-	@has_permissions(change_nickname=True)
-	@command()
-	async def nick(self, ctx, *, nicktochangeto):
-		"""Allows a member to change their nickname."""
-		await discord.Member.edit(ctx.author, nick=nicktochangeto[:32])
-		await ctx.send("Nick successfully changed to " + nicktochangeto[:32])
-		if len(nicktochangeto) > 32:
-			await ctx.send("Warning: truncated nickname to 32 characters")
+    async def _help_cog(self, ctx, cog):
+        """Gets the help message for one cog."""
+        await self._show_help(ctx, None, 'Category: {cog_name}', inspect.cleandoc(cog.__doc__ or ''),
+                              '{cog_name!r} category',
+                              (command for command in ctx.bot.commands if command.instance is cog),
+                              cog_name=type(cog).__name__)
 
-	@has_permissions(create_instant_invite=True)
-	@bot_has_permissions(create_instant_invite=True)
-	@command()
-	async def invites(self, ctx, num, hours=24):
-		"""
-		Generates a set number of single use invites.
-		"""
-		with db.Session() as session:
-			settings = session.query(WelcomeChannel).filter_by(id=ctx.guild.id).one_or_none()
-			if settings is None:
-				await ctx.send("There is no welcome channel set. Please set one using `{0}welcomeconifg channel` and try again.".format(ctx.prefix))
-				return
-			else:
-				invitechannel = ctx.bot.get_channel(settings.channel_id)
-				if invitechannel is None:
-					await ctx.send("There was an issue getting your welcome channel. Please set it again using `{0} welcomeconfig channel`.".format(ctx.prefix))
-					return
-				text = ""
-				for i in range(int(num)):
-					invite = await invitechannel.create_invite(max_age=hours*3600,max_uses=1,unique=True,reason="Autogenerated by {}".format(ctx.author))
-					text += "Invite {0}: <{1}>\n".format(i+1,invite.url)
-				await ctx.send(text)
-				
-	invites.example_usage="""
+    async def _show_help(self, ctx, start_page, title, description, footer, commands, **format_args):
+        """Creates and sends a template help message, with arguments filled in."""
+        format_args['prefix'] = ctx.prefix
+        footer = 'Dozer Help | {} | Page {}'.format(footer,
+                                                    '{page_num} of {len_pages}')  # Page info is inserted as a parameter so page_num and len_pages aren't evaluated now
+        if commands:
+            command_chunks = list(chunk(sorted(commands, key=lambda cmd: cmd.name), 4))
+            format_args['len_pages'] = len(command_chunks)
+            pages = []
+            for page_num, page_commands in enumerate(command_chunks):
+                format_args['page_num'] = page_num + 1
+                page = discord.Embed(title=title.format(**format_args), description=description.format(**format_args),
+                                     color=discord.Color.blue())
+                for command in page_commands:
+                    if command.short_doc:
+                        embed_value = command.short_doc
+                    elif command.example_usage:  # Usage provided - show the user the command to see it
+                        embed_value = 'Use `{0.prefix}{0.invoked_with} {1.qualified_name}` for more information.'.format(
+                            ctx, command)
+                    else:
+                        embed_value = 'No information provided.'
+                    page.add_field(name=ctx.prefix + command.signature, value=embed_value, inline=False)
+                page.set_footer(text=footer.format(**format_args))
+                pages.append(page)
+
+            if start_page is not None:
+                pages.append({'info': start_page})
+
+            if len(pages) == 1:
+                await ctx.send(embed=pages[0])
+            elif start_page is not None:
+                info_emoji = '\N{INFORMATION SOURCE}'
+                p = Paginator(ctx, (info_emoji, ...), pages, start='info',
+                              auto_remove=ctx.channel.permissions_for(ctx.me))
+                async for reaction in p:
+                    if reaction == info_emoji:
+                        p.go_to_page('info')
+            else:
+                await paginate(ctx, pages, auto_remove=ctx.channel.permissions_for(ctx.me))
+        elif start_page:  # No commands - command without subcommands or empty cog - but a usable info page
+            await ctx.send(embed=start_page)
+        else:  # No commands, and no info page
+            format_args['len_pages'] = 1
+            format_args['page_num'] = 1
+            embed = discord.Embed(title=title.format(**format_args), description=description.format(**format_args),
+                                  color=discord.Color.blue())
+            embed.set_footer(text=footer.format(**format_args))
+            await ctx.send(embed=embed)
+
+    @has_permissions(change_nickname=True)
+    @command()
+    async def nick(self, ctx, *, nicktochangeto):
+        """Allows a member to change their nickname."""
+        await discord.Member.edit(ctx.author, nick=nicktochangeto[:32])
+        await ctx.send("Nick successfully changed to " + nicktochangeto[:32])
+        if len(nicktochangeto) > 32:
+            await ctx.send("Warning: truncated nickname to 32 characters")
+
+    @has_permissions(create_instant_invite=True)
+    @bot_has_permissions(create_instant_invite=True)
+    @command()
+    async def invites(self, ctx, num, hours=24):
+        """
+        Generates a set number of single use invites.
+        """
+        with db.Session() as session:
+            settings = session.query(WelcomeChannel).filter_by(id=ctx.guild.id).one_or_none()
+            if settings is None:
+                await ctx.send(
+                    "There is no welcome channel set. Please set one using `{0}welcomeconifg channel` and try again.".format(
+                        ctx.prefix))
+                return
+            else:
+                invitechannel = ctx.bot.get_channel(settings.channel_id)
+                if invitechannel is None:
+                    await ctx.send(
+                        "There was an issue getting your welcome channel. Please set it again using `{0} welcomeconfig channel`.".format(
+                            ctx.prefix))
+                    return
+                text = ""
+                for i in range(int(num)):
+                    invite = await invitechannel.create_invite(max_age=hours * 3600, max_uses=1, unique=True,
+                                                               reason="Autogenerated by {}".format(ctx.author))
+                    text += "Invite {0}: <{1}>\n".format(i + 1, invite.url)
+                await ctx.send(text)
+
+    invites.example_usage = """
 	`{prefix}invtes 5` - Generates 5 single use invites.
 	`{prefix}invites 2 12` Generates 2 single use invites that last for 12 hours.
 	"""
 
+    @command()
+    @has_permissions(administrator=True)
+    async def welcomeconfig(self, ctx, *, welcome_channel: discord.TextChannel):
+        """
+        Sets the new member channel for this guild.
+        """
+        if welcome_channel.guild != ctx.guild:
+            await ctx.send("That channel is not in this guild.")
+            return
+        with db.Session() as Session:
+            settings = Session.query(WelcomeChannel).filter_by(id=ctx.guild.id).one_or_none()
+            if settings is None:
+                settings = WelcomeChannel(id=ctx.guild.id, channel_id=welcome_channel.id)
+                Session.add(settings)
+            else:
+                settings.member_role = welcome_channel.id
+        await ctx.send("Welcome channel set to {}".format(welcome_channel.mention))
 
-	@command()
-	@has_permissions(administrator=True)
-	async def welcomeconfig(self, ctx, *, welcome_channel: discord.TextChannel):
-		"""
-		Sets the new member channel for this guild.
-		"""
-		if welcome_channel.guild != ctx.guild:
-			await ctx.send("That channel is not in this guild.")
-			return
-		with db.Session() as Session:
-			settings = Session.query(WelcomeChannel).filter_by(id=ctx.guild.id).one_or_none()
-			if settings is None:
-				settings = WelcomeChannel(id=ctx.guild.id, channel_id=welcome_channel.id)
-				Session.add(settings)
-			else:
-				settings.member_role = welcome_channel.id
-		await ctx.send("Welcome channel set to {}".format(welcome_channel.mention))
-		
-	welcomeconfig.example_usage="""
+    welcomeconfig.example_usage = """
 	`{prefix}welcomeconfig #new-members` - Sets the invite channel to #new-members.
 	"""
 
 
 def setup(bot):
-	bot.remove_command('help')
-	bot.add_cog(General(bot))
+    bot.remove_command('help')
+    bot.add_cog(General(bot))
+
 
 class WelcomeChannel(db.DatabaseObject):
-	__tablename__ = 'welcome_channel'
-	id = db.Column(db.Integer, primary_key=True)
-	channel_id = db.Column(db.Integer, nullable=True)
+    __tablename__ = 'welcome_channel'
+    id = db.Column(db.Integer, primary_key=True)
+    channel_id = db.Column(db.Integer, nullable=True)

--- a/dozer/cogs/general.py
+++ b/dozer/cogs/general.py
@@ -83,8 +83,7 @@ class General(Cog):
             info.add_field(name='Usage', value=usage.format(prefix=ctx.prefix, name=ctx.invoked_with), inline=False)
         info.set_footer(text='Dozer Help | {!r} command | Info'.format(command.qualified_name))
         await self._show_help(ctx, info, 'Subcommands: {prefix}{signature}', '', '{command.qualified_name!r} command',
-                              command.commands if isinstance(command, Group) else set(), command=command,
-                              signature=command.signature)
+                              command.commands if isinstance(command, Group) else set(), command=command, signature=command.signature)
 
     async def _help_cog(self, ctx, cog):
         """Gets the help message for one cog."""
@@ -104,8 +103,7 @@ class General(Cog):
             pages = []
             for page_num, page_commands in enumerate(command_chunks):
                 format_args['page_num'] = page_num + 1
-                page = discord.Embed(title=title.format(**format_args), description=description.format(**format_args),
-                                     color=discord.Color.blue())
+                page = discord.Embed(title=title.format(**format_args), description=description.format(**format_args), color=discord.Color.blue())
                 for command in page_commands:
                     if command.short_doc:
                         embed_value = command.short_doc
@@ -137,8 +135,7 @@ class General(Cog):
         else:  # No commands, and no info page
             format_args['len_pages'] = 1
             format_args['page_num'] = 1
-            embed = discord.Embed(title=title.format(**format_args), description=description.format(**format_args),
-                                  color=discord.Color.blue())
+            embed = discord.Embed(title=title.format(**format_args), description=description.format(**format_args), color=discord.Color.blue())
             embed.set_footer(text=footer.format(**format_args))
             await ctx.send(embed=embed)
 

--- a/dozer/cogs/info.py
+++ b/dozer/cogs/info.py
@@ -46,9 +46,9 @@ class Info(Cog):
         await ctx.send(embed=e)
 
     member.example_usage = """
-	`{prefix}member` - get information about yourself
-	`{prefix}member cooldude#1234` - get information about cooldude
-	"""
+    `{prefix}member` - get information about yourself
+    `{prefix}member cooldude#1234` - get information about cooldude
+    """
 
     @guild_only()
     @cooldown(1, 10, BucketType.channel)
@@ -71,8 +71,8 @@ class Info(Cog):
         await ctx.send(embed=e)
 
     guild.example_usage = """
-	`{prefix}guild` - get information about this guild
-	"""
+    `{prefix}guild` - get information about this guild
+    """
 
 
 def setup(bot):

--- a/dozer/cogs/info.py
+++ b/dozer/cogs/info.py
@@ -1,73 +1,79 @@
-import discord, unicodedata
+import discord
 from discord.ext.commands import cooldown, BucketType, guild_only
+
 from ._utils import *
 
 blurple = discord.Color.blurple()
 datetime_format = '%Y-%m-%d %I:%M %p'
 
+
 class Info(Cog):
-	"""Commands for getting information about people and things on Discord."""
-	@guild_only()
-	@cooldown(1, 10, BucketType.channel)
-	@command(aliases=['user', 'userinfo', 'memberinfo'])
-	async def member(self, ctx, member: discord.Member=None):
-		"""
-		Retrieve information about a member of the guild.
-		If no arguments are passed, information about the author is used.
-		**This command works without mentions.** Remove the '@' before your mention so you don't ping the person unnecessarily.
-		You can pick a member by:
-		- Username (`cooldude`)
-		- Username and discriminator (`cooldude#1234`)
-		- ID (`326749693969301506`)
-		- Nickname - must be exact and is case-sensitive (`"Mr. Cool Dude III | Team 1234"`)
-		- Mention (not recommended) (`@Mr Cool Dude III | Team 1234`)
-		"""
-		async with ctx.typing():
-			member = member or ctx.author
-			icon_url = member.avatar_url_as(static_format='png')
-			e = discord.Embed(color=member.color)
-			e.set_thumbnail(url=icon_url)
-			e.add_field(name='Name', value=str(member))
-			e.add_field(name='ID', value=member.id)
-			e.add_field(name='Nickname', value=member.nick, inline=member.nick is None)
-			e.add_field(name='Bot Created' if member.bot else 'User Joined Discord', value=member.created_at.strftime(datetime_format))
-			e.add_field(name='Joined Guild', value=member.joined_at.strftime(datetime_format))
-			e.add_field(name='Color', value=str(member.color).upper())
-			
-			e.add_field(name='Status and Game', value=f'{member.status}, '.title() + (f'playing {member.game}' if member.game else 'no game playing'), inline=False)
-			roles = sorted(member.roles, reverse=True)[:-1] # Remove @everyone
-			e.add_field(name='Roles', value=', '.join(role.name for role in roles) or "No roles", inline=False)
-			e.add_field(name='Icon URL', value=icon_url, inline=False)
-		await ctx.send(embed=e)
-	
-	member.example_usage = """
+    """Commands for getting information about people and things on Discord."""
+
+    @guild_only()
+    @cooldown(1, 10, BucketType.channel)
+    @command(aliases=['user', 'userinfo', 'memberinfo'])
+    async def member(self, ctx, member: discord.Member = None):
+        """
+        Retrieve information about a member of the guild.
+        If no arguments are passed, information about the author is used.
+        **This command works without mentions.** Remove the '@' before your mention so you don't ping the person unnecessarily.
+        You can pick a member by:
+        - Username (`cooldude`)
+        - Username and discriminator (`cooldude#1234`)
+        - ID (`326749693969301506`)
+        - Nickname - must be exact and is case-sensitive (`"Mr. Cool Dude III | Team 1234"`)
+        - Mention (not recommended) (`@Mr Cool Dude III | Team 1234`)
+        """
+        async with ctx.typing():
+            member = member or ctx.author
+            icon_url = member.avatar_url_as(static_format='png')
+            e = discord.Embed(color=member.color)
+            e.set_thumbnail(url=icon_url)
+            e.add_field(name='Name', value=str(member))
+            e.add_field(name='ID', value=member.id)
+            e.add_field(name='Nickname', value=member.nick, inline=member.nick is None)
+            e.add_field(name='Bot Created' if member.bot else 'User Joined Discord',
+                        value=member.created_at.strftime(datetime_format))
+            e.add_field(name='Joined Guild', value=member.joined_at.strftime(datetime_format))
+            e.add_field(name='Color', value=str(member.color).upper())
+
+            e.add_field(name='Status and Game', value=f'{member.status}, '.title() + (
+                f'playing {member.game}' if member.game else 'no game playing'), inline=False)
+            roles = sorted(member.roles, reverse=True)[:-1]  # Remove @everyone
+            e.add_field(name='Roles', value=', '.join(role.name for role in roles) or "No roles", inline=False)
+            e.add_field(name='Icon URL', value=icon_url, inline=False)
+        await ctx.send(embed=e)
+
+    member.example_usage = """
 	`{prefix}member` - get information about yourself
 	`{prefix}member cooldude#1234` - get information about cooldude
 	"""
-	
-	@guild_only()
-	@cooldown(1, 10, BucketType.channel)
-	@command(aliases=['server', 'guildinfo', 'serverinfo'])
-	async def guild(self, ctx):
-		"""Retrieve information about this guild."""
-		guild = ctx.guild
-		e = discord.Embed(color=blurple)
-		e.set_thumbnail(url=guild.icon_url)
-		e.add_field(name='Name', value=guild.name)
-		e.add_field(name='ID', value=guild.id)
-		e.add_field(name='Created at', value=guild.created_at.strftime(datetime_format))
-		e.add_field(name='Owner', value=guild.owner)
-		e.add_field(name='Members', value=guild.member_count)
-		e.add_field(name='Channels', value=len(guild.channels))
-		e.add_field(name='Roles', value=len(guild.role_hierarchy)-1) # Remove @everyone
-		e.add_field(name='Emoji', value=len(guild.emojis))
-		e.add_field(name='Region', value=guild.region.name)
-		e.add_field(name='Icon URL', value=guild.icon_url or 'This guild has no icon.')
-		await ctx.send(embed=e)
-	
-	guild.example_usage = """
+
+    @guild_only()
+    @cooldown(1, 10, BucketType.channel)
+    @command(aliases=['server', 'guildinfo', 'serverinfo'])
+    async def guild(self, ctx):
+        """Retrieve information about this guild."""
+        guild = ctx.guild
+        e = discord.Embed(color=blurple)
+        e.set_thumbnail(url=guild.icon_url)
+        e.add_field(name='Name', value=guild.name)
+        e.add_field(name='ID', value=guild.id)
+        e.add_field(name='Created at', value=guild.created_at.strftime(datetime_format))
+        e.add_field(name='Owner', value=guild.owner)
+        e.add_field(name='Members', value=guild.member_count)
+        e.add_field(name='Channels', value=len(guild.channels))
+        e.add_field(name='Roles', value=len(guild.role_hierarchy) - 1)  # Remove @everyone
+        e.add_field(name='Emoji', value=len(guild.emojis))
+        e.add_field(name='Region', value=guild.region.name)
+        e.add_field(name='Icon URL', value=guild.icon_url or 'This guild has no icon.')
+        await ctx.send(embed=e)
+
+    guild.example_usage = """
 	`{prefix}guild` - get information about this guild
 	"""
 
+
 def setup(bot):
-	bot.add_cog(Info(bot))
+    bot.add_cog(Info(bot))

--- a/dozer/cogs/maintenance.py
+++ b/dozer/cogs/maintenance.py
@@ -1,65 +1,71 @@
-import os, sys
-from ._utils import *
+import os
+import sys
+
 from discord.ext.commands import NotOwner
+
 from dozer.bot import logger
+from ._utils import *
+
 
 class Maintenance(Cog):
-	"""
-	Commands for performing maintenance on the bot.
-	These commands are restricted to bot developers.
-	"""
-	def __local_check(self, ctx): # All of this cog is only available to devs
-		if ctx.author.id not in ctx.bot.config['developers']:
-			raise NotOwner('you are not a developer!')
-		return True
-	
-	@command()
-	async def shutdown(self, ctx):
-		"""Force-stops the bot."""
-		await ctx.send('Shutting down')
-		logger.info('Shutting down at request of {0.author} (in {0.guild}, #{0.channel})'.format(ctx))
-		await self.bot.shutdown()
-	
-	shutdown.example_usage = """
+    """
+    Commands for performing maintenance on the bot.
+    These commands are restricted to bot developers.
+    """
+
+    def __local_check(self, ctx):  # All of this cog is only available to devs
+        if ctx.author.id not in ctx.bot.config['developers']:
+            raise NotOwner('you are not a developer!')
+        return True
+
+    @command()
+    async def shutdown(self, ctx):
+        """Force-stops the bot."""
+        await ctx.send('Shutting down')
+        logger.info('Shutting down at request of {0.author} (in {0.guild}, #{0.channel})'.format(ctx))
+        await self.bot.shutdown()
+
+    shutdown.example_usage = """
 	`{prefix}shutdown` - stop the bot
 	"""
-	
-	@command()
-	async def restart(self, ctx):
-		"""Restarts the bot."""
-		await ctx.send('Restarting')
-		await self.bot.shutdown()
-		script = sys.argv[0]
-		if script.startswith(os.getcwd()):
-			script = script[len(os.getcwd()):].lstrip(os.sep)
-		
-		if script.endswith('__main__.py'):
-			args = [sys.executable, '-m', script[:-len('__main__.py')].rstrip(os.sep).replace(os.sep, '.')]
-		else:
-			args = [sys.executable, script]
-		os.execv(sys.executable, args + sys.argv[1:])
-	
-	restart.example_usage = """
+
+    @command()
+    async def restart(self, ctx):
+        """Restarts the bot."""
+        await ctx.send('Restarting')
+        await self.bot.shutdown()
+        script = sys.argv[0]
+        if script.startswith(os.getcwd()):
+            script = script[len(os.getcwd()):].lstrip(os.sep)
+
+        if script.endswith('__main__.py'):
+            args = [sys.executable, '-m', script[:-len('__main__.py')].rstrip(os.sep).replace(os.sep, '.')]
+        else:
+            args = [sys.executable, script]
+        os.execv(sys.executable, args + sys.argv[1:])
+
+    restart.example_usage = """
 	`{prefix}restart` - restart the bot
 	"""
-	
-	@command()
-	async def update(self, ctx):
-		"""
-		Pulls code from GitHub and restarts.
-		This pulls from whatever repository `origin` is linked to.
-		If there are changes to download, and the download is successful, the bot restarts to apply changes.
-		"""
-		res = os.popen("git pull origin master").read()
-		if res.startswith('Already up-to-date.'):
-			await ctx.send('```\n' + res + '```')
-		else:
-			await ctx.send('```\n' + res + '```')
-			await ctx.bot.get_command('restart').callback(self, ctx)
-	
-	update.example_usage = """
+
+    @command()
+    async def update(self, ctx):
+        """
+        Pulls code from GitHub and restarts.
+        This pulls from whatever repository `origin` is linked to.
+        If there are changes to download, and the download is successful, the bot restarts to apply changes.
+        """
+        res = os.popen("git pull origin master").read()
+        if res.startswith('Already up-to-date.'):
+            await ctx.send('```\n' + res + '```')
+        else:
+            await ctx.send('```\n' + res + '```')
+            await ctx.bot.get_command('restart').callback(self, ctx)
+
+    update.example_usage = """
 	`{prefix}update` - update to the latest commit and restart
 	"""
 
+
 def setup(bot):
-	bot.add_cog(Maintenance(bot))
+    bot.add_cog(Maintenance(bot))

--- a/dozer/cogs/maintenance.py
+++ b/dozer/cogs/maintenance.py
@@ -26,8 +26,8 @@ class Maintenance(Cog):
         await self.bot.shutdown()
 
     shutdown.example_usage = """
-	`{prefix}shutdown` - stop the bot
-	"""
+    `{prefix}shutdown` - stop the bot
+    """
 
     @command()
     async def restart(self, ctx):
@@ -45,8 +45,8 @@ class Maintenance(Cog):
         os.execv(sys.executable, args + sys.argv[1:])
 
     restart.example_usage = """
-	`{prefix}restart` - restart the bot
-	"""
+    `{prefix}restart` - restart the bot
+    """
 
     @command()
     async def update(self, ctx):
@@ -63,8 +63,8 @@ class Maintenance(Cog):
             await ctx.bot.get_command('restart').callback(self, ctx)
 
     update.example_usage = """
-	`{prefix}update` - update to the latest commit and restart
-	"""
+    `{prefix}update` - update to the latest commit and restart
+    """
 
 
 def setup(bot):

--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -1,247 +1,259 @@
-import asyncio, discord, functools, re
+import asyncio
+import discord
+import re
+
 from discord.ext.commands import BadArgument, has_permissions, bot_has_permissions, RoleConverter
-from .. import db
+
 from ._utils import *
+from .. import db
 from ..utils import clean
 
 
 class SafeRoleConverter(RoleConverter):
-	async def convert(self, ctx, arg):
-		try:
-			return await super().convert(ctx, arg)
-		except BadArgument:
-			if arg.casefold() in ('everyone', '@everyone', '@/everyone', '@.everyone', '@ everyone', '@\N{ZERO WIDTH SPACE}everyone'):
-				return ctx.guild.default_role
-			else:
-				raise
+    async def convert(self, ctx, arg):
+        try:
+            return await super().convert(ctx, arg)
+        except BadArgument:
+            if arg.casefold() in (
+            'everyone', '@everyone', '@/everyone', '@.everyone', '@ everyone', '@\N{ZERO WIDTH SPACE}everyone'):
+                return ctx.guild.default_role
+            else:
+                raise
 
 
 class Moderation(Cog):
-	async def modlogger(self, ctx, action, target, reason):
-		modlogmessage = "{} has {} {} because {}".format(ctx.author, action, target, reason)
-		modlogmessage = clean(ctx=ctx, text=modlogmessage)
-		with db.Session() as session:
-			modlogchannel = session.query(Guildmodlog).filter_by(id=ctx.guild.id).one_or_none()
-			await ctx.send(modlogmessage)
-			if modlogchannel is not None:
-				channel = ctx.guild.get_channel(modlogchannel.modlog_channel)
-				if channel is not None:
-					await channel.send(modlogmessage)
-			else:
-				await ctx.send("Please configure modlog channel to enable modlog functionality")
+    async def mod_logger(self, ctx, action, target, reason):
+        modlog_message = "{} has {} {} because {}".format(ctx.author, action, target, reason)
+        modlog_message = clean(ctx=ctx, text=modlog_message)
+        with db.Session() as session:
+            modlog_channel = session.query(GuildModLog).filter_by(id=ctx.guild.id).one_or_none()
+            await ctx.send(modlog_message)
+            if modlog_channel is not None:
+                channel = ctx.guild.get_channel(modlog_channel.modlog_channel)
+                if channel is not None:
+                    await channel.send(modlog_message)
+            else:
+                await ctx.send("Please configure modlog channel to enable modlog functionality")
 
-	async def permoverride(self, user, **overwrites):
-		coros = []
-		for channel in user.guild.channels:
-			overwrite = channel.overwrites_for(user)
-			can_permoverride = channel.permissions_for(user.guild.me).manage_roles
-			if can_permoverride:
-				overwrite.update(**overwrites)
-				coros.append(channel.set_permissions(target=user, overwrite=None if overwrite.is_empty() else overwrite))
-		await asyncio.gather(*coros)
+    async def perm_override(self, user, **overwrites):
+        coros = []
+        for channel in user.guild.channels:
+            overwrite = channel.overwrites_for(user)
+            can_perm_override = channel.permissions_for(user.guild.me).manage_roles
+            if can_perm_override:
+                overwrite.update(**overwrites)
+                coros.append(
+                    channel.set_permissions(target=user, overwrite=None if overwrite.is_empty() else overwrite))
+        await asyncio.gather(*coros)
 
-	async def punishmenttimer(self, ctx, timing, target, lookup, reason):
-		regexstring = re.compile(r"((?P<hours>\d+)h)?((?P<minutes>\d+)m)?")
-		regexiter = re.match(regexstring, timing)
-		matches = regexiter.groupdict()
-		try:
-			hours = int(matches.get('hours'))
-		except:
-			hours = 0
-		try:
-			minutes = int(matches.get('minutes'))
-		except:
-			minutes = 0
-		time = (hours * 3600) + (minutes * 60)
-		if time is 0:
-			if lookup == Deafen:
-				await self.modlogger(ctx=ctx, action="deafened", target=target, reason=reason)
-			if lookup == Guildmute:
-				await self.modlogger(ctx=ctx, action="muted", target=target, reason=reason)
-		if time is not 0:
-			reasoning = re.sub(pattern=regexstring, string=reason, repl="").lstrip("  ")
-			if lookup == Deafen:
-				await self.modlogger(ctx=ctx, action="deafened", target=target, reason=reasoning)
-			if lookup == Guildmute:
-				await self.modlogger(ctx=ctx, action="muted", target=target, reason=reasoning)
-			await asyncio.sleep(time)
-			with db.Session() as session:
-				user = session.query(lookup).filter_by(id=target.id).one_or_none()
-				if user is not None:
-					if lookup == Deafen:
-						self.bot.loop.create_task(coro=self.undeafen.callback(self=self, ctx=ctx, member_mentions=target))
-					if lookup == Guildmute:
-						self.bot.loop.create_task(coro=self.unmute.callback(self=self, ctx=ctx, member_mentions=target))
+    async def punishment_timer(self, ctx, timing, target, lookup, reason):
+        regex_string = re.compile(r"((?P<hours>\d+)h)?((?P<minutes>\d+)m)?")
+        matches = re.match(regex_string, timing).groupdict()
+        try:
+            hours = int(matches.get('hours'))
+        except:
+            hours = 0
+        try:
+            minutes = int(matches.get('minutes'))
+        except:
+            minutes = 0
+        time = (hours * 3600) + (minutes * 60)
+        if time is 0:
+            if lookup == Deafen:
+                await self.mod_logger(ctx=ctx, action="deafened", target=target, reason=reason)
+            if lookup == GuildMute:
+                await self.mod_logger(ctx=ctx, action="muted", target=target, reason=reason)
+        if time is not 0:
+            reasoning = re.sub(pattern=regex_string, string=reason, repl="").lstrip("  ")
+            if lookup == Deafen:
+                await self.mod_logger(ctx=ctx, action="deafened", target=target, reason=reasoning)
+            if lookup == GuildMute:
+                await self.mod_logger(ctx=ctx, action="muted", target=target, reason=reasoning)
+            await asyncio.sleep(time)
+            with db.Session() as session:
+                user = session.query(lookup).filter_by(id=target.id).one_or_none()
+                if user is not None:
+                    if lookup == Deafen:
+                        self.bot.loop.create_task(
+                            coro=self.undeafen.callback(self=self, ctx=ctx, member_mentions=target))
+                    if lookup == GuildMute:
+                        self.bot.loop.create_task(coro=self.unmute.callback(self=self, ctx=ctx, member_mentions=target))
 
+    async def _check_links_warn(self, msg, role):
+        warn_msg = await msg.channel.send(f"{msg.author.mention}, you need the `{role.name}` role to post links!")
+        await asyncio.sleep(3)
+        await warn_msg.delete()
 
-	async def _check_links_warn(self, msg, role):
-		warn_msg = await msg.channel.send(f"{msg.author.mention}, you need the `{role.name}` role to post links!")
-		await asyncio.sleep(3)
-		await warn_msg.delete()
+    async def check_links(self, msg):
+        if msg.guild is None or not msg.guild.me.guild_permissions.manage_messages:
+            return
+        with db.Session() as session:
+            config = session.query(GuildMessageLinks).filter_by(guild_id=msg.guild.id).one_or_none()
+            if config is None:
+                return
+            role = discord.utils.get(msg.guild.roles, id=config.role_id)
+            if role is None:
+                return
+            if role not in msg.author.roles and re.search("https?://", msg.content):
+                await msg.delete()
+                self.bot.loop.create_task(coro=self._check_links_warn(msg, role))
+                return True
+        return False
 
-	async def check_links(self, msg):
-		if msg.guild is None or not msg.guild.me.guild_permissions.manage_messages:
-			return
-		with db.Session() as session:
-			config = session.query(GuildMessageLinks).filter_by(guild_id=msg.guild.id).one_or_none()
-			if config is None:
-				return
-			role = discord.utils.get(msg.guild.roles, id=config.role_id)
-			if role is None:
-				return
-			if role not in msg.author.roles and re.search("https?://", msg.content):
-				await msg.delete()
-				self.bot.loop.create_task(coro=self._check_links_warn(msg, role))
-				return True
-		return False
+    @command()
+    @has_permissions(ban_members=True)
+    @bot_has_permissions(ban_members=True)
+    async def ban(self, ctx, user_mentions: discord.User, *, reason="No reason provided"):
+        "Bans the user mentioned."
+        await ctx.guild.ban(user_mentions, reason=reason)
+        await self.mod_logger(ctx=ctx, action="banned", target=user_mentions, reason=reason)
 
-	@command()
-	@has_permissions(ban_members=True)
-	@bot_has_permissions(ban_members=True)
-	async def ban(self, ctx, user_mentions: discord.User, *, reason="No reason provided"):
-		"Bans the user mentioned."
-		await ctx.guild.ban(user_mentions, reason=reason)
-		await self.modlogger(ctx=ctx, action="banned", target=user_mentions, reason=reason)
+    @command()
+    @has_permissions(ban_members=True)
+    @bot_has_permissions(ban_members=True)
+    async def unban(self, ctx, user_mentions: discord.User, *, reason="No reason provided"):
+        "Unbans the user ID mentioned."
+        await ctx.guild.unban(user_mentions, reason=reason)
+        await self.mod_logger(ctx=ctx, action="unbanned", target=user_mentions, reason=reason)
 
-	@command()
-	@has_permissions(ban_members=True)
-	@bot_has_permissions(ban_members=True)
-	async def unban(self, ctx, user_mentions: discord.User, *, reason="No reason provided"):
-		"Unbans the user ID mentioned."
-		await ctx.guild.unban(user_mentions, reason=reason)
-		await self.modlogger(ctx=ctx, action="unbanned", target=user_mentions, reason=reason)
+    @command()
+    @has_permissions(kick_members=True)
+    @bot_has_permissions(kick_members=True)
+    async def kick(self, ctx, user_mentions: discord.User, *, reason="No reason provided"):
+        "Kicks the user mentioned."
+        await ctx.guild.kick(user_mentions, reason=reason)
+        await self.mod_logger(ctx=ctx, action="kicked", target=user_mentions, reason=reason)
 
-	@command()
-	@has_permissions(kick_members=True)
-	@bot_has_permissions(kick_members=True)
-	async def kick(self, ctx, user_mentions: discord.User, *, reason="No reason provided"):
-		"Kicks the user mentioned."
-		await ctx.guild.kick(user_mentions, reason=reason)
-		await self.modlogger(ctx=ctx, action="kicked", target=user_mentions, reason=reason)
+    @command()
+    @has_permissions(administrator=True)
+    async def modlogconfig(self, ctx, channel_mentions: discord.TextChannel):
+        """Set the modlog channel for a server by passing the channel id"""
+        with db.Session() as session:
+            config = session.query(GuildModLog).filter_by(id=str(ctx.guild.id)).one_or_none()
+            if config is not None:
+                config.name = ctx.guild.name
+                config.modlog_channel = str(channel_mentions.id)
+            else:
+                config = GuildModLog(id=ctx.guild.id, modlog_channel=channel_mentions.id, name=ctx.guild.name)
+                session.add(config)
+            await ctx.send(ctx.message.author.mention + ', modlog settings configured!')
 
-	@command()
-	@has_permissions(administrator=True)
-	async def modlogconfig(self, ctx, channel_mentions: discord.TextChannel):
-		"""Set the modlog channel for a server by passing the channel id"""
-		with db.Session() as session:
-			config = session.query(Guildmodlog).filter_by(id=str(ctx.guild.id)).one_or_none()
-			if config is not None:
-				config.name = ctx.guild.name
-				config.modlog_channel = str(channel_mentions.id)
-			else:
-				config = Guildmodlog(id=ctx.guild.id, modlog_channel=channel_mentions.id, name=ctx.guild.name)
-				session.add(config)
-			await ctx.send(ctx.message.author.mention + ', modlog settings configured!')
+    async def on_message(self, message):
+        if message.author.bot: return
+        if not message.guild.me.guild_permissions.manage_roles or message.guild is None: return
 
-	async def on_message(self, message):
-		if message.author.bot: return
-		if not message.guild.me.guild_permissions.manage_roles or message.guild is None: return
+        if await self.check_links(message):
+            return
+        with db.Session() as session:
+            config = session.query(GuildNewMember).filter_by(guild_id=message.guild.id).one_or_none()
+            if config is not None:
+                string = config.message
+                content = message.content.casefold()
+                if string not in content: return
+                channel = config.channel_id
+                role_id = config.role_id
+                if message.channel.id != channel: return
+                await message.author.add_roles(discord.utils.get(message.guild.roles, id=role_id))
 
-		if await self.check_links(message):
-			return
-		with db.Session() as session:
-			config = session.query(GuildNewMember).filter_by(guild_id=message.guild.id).one_or_none()
-			if config is not None:
-				string = config.message
-				content = message.content.casefold()
-				if string not in content: return
-				channel = config.channel_id
-				role_id = config.role_id
-				if message.channel.id != channel: return
-				await message.author.add_roles(discord.utils.get(message.guild.roles, id=role_id))
+    @command()
+    @has_permissions(administrator=True)
+    async def nmconfig(self, ctx, channel_mention: discord.TextChannel, role: discord.Role, *, message):
+        """Sets the config for the new members channel"""
+        with db.Session() as session:
+            config = session.query(GuildNewMember).filter_by(guild_id=ctx.guild.id).one_or_none()
+            if config is not None:
+                config.channel_id = channel_mention.id
+                config.role_id = role.id
+                config.message = message.casefold()
+            else:
+                config = GuildNewMember(guild_id=ctx.guild.id, channel_id=channel_mention.id, role_id=role.id,
+                                        message=message.casefold())
+                session.add(config)
 
-	@command()
-	@has_permissions(administrator=True)
-	async def nmconfig(self, ctx, channel_mention: discord.TextChannel, role: discord.Role, *, message):
-		"""Sets the config for the new members channel"""
-		with db.Session() as session:
-			config = session.query(GuildNewMember).filter_by(guild_id=ctx.guild.id).one_or_none()
-			if config is not None:
-				config.channel_id = channel_mention.id
-				config.role_id = role.id
-				config.message = message.casefold()
-			else:
-				config = GuildNewMember(guild_id=ctx.guild.id, channel_id=channel_mention.id, role_id=role.id, message=message.casefold())
-				session.add(config)
+        role_name = role.name
+        await ctx.send(
+            "New Member Channel configured as: {channel}. Role configured as: {role}. Message: {message}".format(
+                channel=channel_mention.name, role=role_name, message=message))
 
-		role_name = role.name
-		await ctx.send("New Member Channel configured as: {channel}. Role configured as: {role}. Message: {message}".format(channel=channel_mention.name, role=role_name, message=message))
-
-	nmconfig.example_usage = """
+    nmconfig.example_usage = """
 	`{prefix}nmconfig #new_members Member I have read the rules and regulations` - Configures the #new_members channel so if someone types "I have read the rules and regulations" it assigns them the Member role. 
 	"""
 
-	@command()
-	@has_permissions(manage_roles=True)
-	@bot_has_permissions(manage_roles=True)
-	async def timeout(self, ctx, duration: float):
-		"""Set a timeout (no sending messages or adding reactions) on the current channel."""
-		with db.Session() as session:
-			settings = session.query(MemberRole).filter_by(id=ctx.guild.id).one_or_none()
-			if settings is None:
-				settings = MemberRole(id=ctx.guild.id)
-				session.add(settings)
+    @command()
+    @has_permissions(manage_roles=True)
+    @bot_has_permissions(manage_roles=True)
+    async def timeout(self, ctx, duration: float):
+        """Set a timeout (no sending messages or adding reactions) on the current channel."""
+        with db.Session() as session:
+            settings = session.query(MemberRole).filter_by(id=ctx.guild.id).one_or_none()
+            if settings is None:
+                settings = MemberRole(id=ctx.guild.id)
+                session.add(settings)
 
-			member_role = discord.utils.get(ctx.guild.roles, id=settings.member_role) # None-safe - nonexistent or non-configured role return None
+            member_role = discord.utils.get(ctx.guild.roles,
+                                            id=settings.member_role)  # None-safe - nonexistent or non-configured role return None
 
-		if member_role is not None:
-			targets = {member_role}
-		else:
-			await ctx.send('{0.author.mention}, the members role has not been configured. This may not work as expected. Use `{0.prefix}help memberconfig` to see how to set this up.'.format(ctx))
-			targets = set(sorted(ctx.guild.roles)[:ctx.author.top_role.position])
+        if member_role is not None:
+            targets = {member_role}
+        else:
+            await ctx.send(
+                '{0.author.mention}, the members role has not been configured. This may not work as expected. Use `{0.prefix}help memberconfig` to see how to set this up.'.format(
+                    ctx))
+            targets = set(sorted(ctx.guild.roles)[:ctx.author.top_role.position])
 
-		to_restore = [(target, ctx.channel.overwrites_for(target)) for target in targets]
-		for target, overwrite in to_restore:
-			new_overwrite = discord.PermissionOverwrite.from_pair(*overwrite.pair())
-			new_overwrite.update(send_messages=False, add_reactions=False)
-			await ctx.channel.set_permissions(target, overwrite=new_overwrite)
+        to_restore = [(target, ctx.channel.overwrites_for(target)) for target in targets]
+        for target, overwrite in to_restore:
+            new_overwrite = discord.PermissionOverwrite.from_pair(*overwrite.pair())
+            new_overwrite.update(send_messages=False, add_reactions=False)
+            await ctx.channel.set_permissions(target, overwrite=new_overwrite)
 
-		for allow_target in (ctx.me, ctx.author):
-			overwrite = ctx.channel.overwrites_for(allow_target)
-			new_overwrite = discord.PermissionOverwrite.from_pair(*overwrite.pair())
-			new_overwrite.update(send_messages=True)
-			await ctx.channel.set_permissions(allow_target, overwrite=new_overwrite)
-			to_restore.append((allow_target, overwrite))
+        for allow_target in (ctx.me, ctx.author):
+            overwrite = ctx.channel.overwrites_for(allow_target)
+            new_overwrite = discord.PermissionOverwrite.from_pair(*overwrite.pair())
+            new_overwrite.update(send_messages=True)
+            await ctx.channel.set_permissions(allow_target, overwrite=new_overwrite)
+            to_restore.append((allow_target, overwrite))
 
-		e = discord.Embed(title='Timeout - {}s'.format(duration), description='This channel has been timed out.', color=discord.Color.blue())
-		e.set_author(name=ctx.author.display_name, icon_url=ctx.author.avatar_url_as(format='png', size=32))
-		msg = await ctx.send(embed=e)
+        e = discord.Embed(title='Timeout - {}s'.format(duration), description='This channel has been timed out.',
+                          color=discord.Color.blue())
+        e.set_author(name=ctx.author.display_name, icon_url=ctx.author.avatar_url_as(format='png', size=32))
+        msg = await ctx.send(embed=e)
 
-		await asyncio.sleep(duration)
+        await asyncio.sleep(duration)
 
-		for target, overwrite in to_restore:
-			if all(permission is None for _, permission in overwrite):
-				await ctx.channel.set_permissions(target, overwrite=None)
-			else:
-				await ctx.channel.set_permissions(target, overwrite=overwrite)
+        for target, overwrite in to_restore:
+            if all(permission is None for _, permission in overwrite):
+                await ctx.channel.set_permissions(target, overwrite=None)
+            else:
+                await ctx.channel.set_permissions(target, overwrite=overwrite)
 
-		e.description = 'The timeout has ended.'
-		await msg.edit(embed=e)
+        e.description = 'The timeout has ended.'
+        await msg.edit(embed=e)
 
-	timeout.example_usage = """
+    timeout.example_usage = """
 	`{prefix}timeout 60` - prevents sending messages in this channel for 1 minute (60s)
 	"""
 
-	@command()
-	@has_permissions(administrator=True)
-	async def memberconfig(self, ctx, *, member_role: SafeRoleConverter):
-		"""
-		Set the member role for the guild.
-		The member role is the role used for the timeout command. It should be a role that all members of the server have.
-		"""
-		if member_role >= ctx.author.top_role:
-			raise BadArgument('member role cannot be higher than your top role!')
+    @command()
+    @has_permissions(administrator=True)
+    async def memberconfig(self, ctx, *, member_role: SafeRoleConverter):
+        """
+        Set the member role for the guild.
+        The member role is the role used for the timeout command. It should be a role that all members of the server have.
+        """
+        if member_role >= ctx.author.top_role:
+            raise BadArgument('member role cannot be higher than your top role!')
 
-		with db.Session() as session:
-			settings = session.query(MemberRole).filter_by(id=ctx.guild.id).one_or_none()
-			if settings is None:
-				settings = MemberRole(id=ctx.guild.id, member_role=member_role.id)
-				session.add(settings)
-			else:
-				settings.member_role = member_role.id
-		await ctx.send('Member role set as `{}`.'.format(member_role.name))
+        with db.Session() as session:
+            settings = session.query(MemberRole).filter_by(id=ctx.guild.id).one_or_none()
+            if settings is None:
+                settings = MemberRole(id=ctx.guild.id, member_role=member_role.id)
+                session.add(settings)
+            else:
+                settings.member_role = member_role.id
+        await ctx.send('Member role set as `{}`.'.format(member_role.name))
 
-	memberconfig.example_usage = """
+    memberconfig.example_usage = """
 	`{prefix}memberconfig Members` - set a role called "Members" as the member role
 	`{prefix}memberconfig @everyone` - set the default role as the member role
 	`{prefix}memberconfig everyone` - set the default role as the member role (ping-safe)
@@ -250,27 +262,27 @@ class Moderation(Cog):
 	`{prefix}memberconfig @/everyone` - set the default role as the member role (ping-safe)
 	"""
 
-	@command()
-	@has_permissions(administrator=True)
-	@bot_has_permissions(manage_messages=True)
-	async def linkscrubconfig(self, ctx, *, link_role: SafeRoleConverter):
-		"""
-		Set a role that users must have in order to post links.
-		This accepts the safe default role conventions that the memberconfig command does.
-		"""
-		if link_role >= ctx.author.top_role:
-			raise BadArgument('Link role cannot be higher than your top role!')
+    @command()
+    @has_permissions(administrator=True)
+    @bot_has_permissions(manage_messages=True)
+    async def linkscrubconfig(self, ctx, *, link_role: SafeRoleConverter):
+        """
+        Set a role that users must have in order to post links.
+        This accepts the safe default role conventions that the memberconfig command does.
+        """
+        if link_role >= ctx.author.top_role:
+            raise BadArgument('Link role cannot be higher than your top role!')
 
-		with db.Session() as session:
-			settings = session.query(GuildMessageLinks).filter_by(guild_id=ctx.guild.id).one_or_none()
-			if settings is None:
-				settings = GuildMessageLinks(guild_id=ctx.guild.id, role_id=link_role.id)
-				session.add(settings)
-			else:
-				settings.role_id = link_role.id
-		await ctx.send(f'Link role set as `{link_role.name}`.')
+        with db.Session() as session:
+            settings = session.query(GuildMessageLinks).filter_by(guild_id=ctx.guild.id).one_or_none()
+            if settings is None:
+                settings = GuildMessageLinks(guild_id=ctx.guild.id, role_id=link_role.id)
+                session.add(settings)
+            else:
+                settings.role_id = link_role.id
+        await ctx.send(f'Link role set as `{link_role.name}`.')
 
-	linkscrubconfig.example_usage = """
+    linkscrubconfig.example_usage = """
 	`{prefix}linkscrubconfig Links` - set a role called "Links" as the link role
 	`{prefix}linkscrubconfig @everyone` - set the default role as the link role
 	`{prefix}linkscrubconfig everyone` - set the default role as the link role (ping-safe)
@@ -279,276 +291,281 @@ class Moderation(Cog):
 	`{prefix}linkscrubconfig @/everyone` - set the default role as the link role (ping-safe)
 	"""
 
-	@command()
-	@has_permissions(administrator=True)
-	async def memberlogconfig(self, ctx, channel_mentions: discord.TextChannel):
-		"""Set the modlog channel for a server by passing the channel id"""
-		with db.Session() as session:
-			config = session.query(Guildmemberlog).filter_by(id=str(ctx.guild.id)).one_or_none()
-			if config is not None:
-				config.name = ctx.guild.name
-				config.memberlog_channel = str(channel_mentions.id)
-			else:
-				config = Guildmemberlog(id=ctx.guild.id, memberlog_channel=channel_mentions.id, name=ctx.guild.name)
-				session.add(config)
-			await ctx.send(ctx.message.author.mention + ', memberlog settings configured!')
+    @command()
+    @has_permissions(administrator=True)
+    async def memberlogconfig(self, ctx, channel_mentions: discord.TextChannel):
+        """Set the modlog channel for a server by passing the channel id"""
+        with db.Session() as session:
+            config = session.query(GuildMemberLog).filter_by(id=str(ctx.guild.id)).one_or_none()
+            if config is not None:
+                config.name = ctx.guild.name
+                config.memberlog_channel = str(channel_mentions.id)
+            else:
+                config = GuildMemberLog(id=ctx.guild.id, memberlog_channel=channel_mentions.id, name=ctx.guild.name)
+                session.add(config)
+            await ctx.send(ctx.message.author.mention + ', memberlog settings configured!')
 
-	@command()
-	@has_permissions(administrator=True)
-	async def messagelogconfig(self, ctx, channel_mentions: discord.TextChannel):
-		"""Set the modlog channel for a server by passing the channel id"""
-		with db.Session() as session:
-			config = session.query(Guildmessagelog).filter_by(id=str(ctx.guild.id)).one_or_none()
-			if config is not None:
-				config.name = ctx.guild.name
-				config.messagelog_channel = str(channel_mentions.id)
-			else:
-				config = Guildmessagelog(id=ctx.guild.id, messagelog_channel=channel_mentions.id, name=ctx.guild.name)
-				session.add(config)
-			await ctx.send(ctx.message.author.mention + ', messagelog settings configured!')
+    @command()
+    @has_permissions(administrator=True)
+    async def messagelogconfig(self, ctx, channel_mentions: discord.TextChannel):
+        """Set the modlog channel for a server by passing the channel id"""
+        with db.Session() as session:
+            config = session.query(GuildMessageLog).filter_by(id=str(ctx.guild.id)).one_or_none()
+            if config is not None:
+                config.name = ctx.guild.name
+                config.messagelog_channel = str(channel_mentions.id)
+            else:
+                config = GuildMessageLog(id=ctx.guild.id, messagelog_channel=channel_mentions.id, name=ctx.guild.name)
+                session.add(config)
+            await ctx.send(ctx.message.author.mention + ', messagelog settings configured!')
 
-	async def on_member_join(self, member):
-		join = discord.Embed(type='rich', color=0x00FF00)
-		join.set_author(name = 'Member Joined', icon_url = member.avatar_url_as(format='png', size=32))
-		join.description = "{0.mention}\n{0} ({0.id})".format(member)
-		join.set_footer(text="{} | {} members".format(member.guild.name, member.guild.member_count))
-		with db.Session() as session:
-			memberlogchannel = session.query(Guildmemberlog).filter_by(id=member.guild.id).one_or_none()
-			if memberlogchannel is not None:
-				channel = member.guild.get_channel(memberlogchannel.memberlog_channel)
-				await channel.send(embed=join)
-			user = session.query(Guildmute).filter_by(id=member.id, guild=member.guild.id).one_or_none()
-			if user is not None:
-				await self.permoverride(member, add_reactions=False, send_messages=False)
-			user = session.query(Deafen).filter_by(id=member.id, guild=member.guild.id).one_or_none()
-			if user is not None:
-				await self.permoverride(member, read_messages=False)
+    async def on_member_join(self, member):
+        join = discord.Embed(type='rich', color=0x00FF00)
+        join.set_author(name='Member Joined', icon_url=member.avatar_url_as(format='png', size=32))
+        join.description = "{0.mention}\n{0} ({0.id})".format(member)
+        join.set_footer(text="{} | {} members".format(member.guild.name, member.guild.member_count))
+        with db.Session() as session:
+            memberlogchannel = session.query(GuildMemberLog).filter_by(id=member.guild.id).one_or_none()
+            if memberlogchannel is not None:
+                channel = member.guild.get_channel(memberlogchannel.memberlog_channel)
+                await channel.send(embed=join)
+            user = session.query(GuildMute).filter_by(id=member.id, guild=member.guild.id).one_or_none()
+            if user is not None:
+                await self.perm_override(member, add_reactions=False, send_messages=False)
+            user = session.query(Deafen).filter_by(id=member.id, guild=member.guild.id).one_or_none()
+            if user is not None:
+                await self.perm_override(member, read_messages=False)
 
-	async def on_member_remove(self, member):
-		leave = discord.Embed(type='rich', color=0xFF0000)
-		leave.set_author(name = 'Member Left', icon_url = member.avatar_url_as(format='png', size=32))
-		leave.description = "{0.mention}\n{0} ({0.id})".format(member)
-		leave.set_footer(text="{} | {} members".format(member.guild.name, member.guild.member_count))
-		with db.Session() as session:
-			memberlogchannel = session.query(Guildmemberlog).filter_by(id=member.guild.id).one_or_none()
-			if memberlogchannel is not None:
-				channel = member.guild.get_channel(memberlogchannel.memberlog_channel)
-				await channel.send(embed=leave)
+    async def on_member_remove(self, member):
+        leave = discord.Embed(type='rich', color=0xFF0000)
+        leave.set_author(name='Member Left', icon_url=member.avatar_url_as(format='png', size=32))
+        leave.description = "{0.mention}\n{0} ({0.id})".format(member)
+        leave.set_footer(text="{} | {} members".format(member.guild.name, member.guild.member_count))
+        with db.Session() as session:
+            memberlogchannel = session.query(GuildMemberLog).filter_by(id=member.guild.id).one_or_none()
+            if memberlogchannel is not None:
+                channel = member.guild.get_channel(memberlogchannel.memberlog_channel)
+                await channel.send(embed=leave)
 
-	async def on_message_delete(self, message):
-		e = discord.Embed(type='rich')
-		e.title = 'Message Deletion'
-		e.color = 0xFF0000
-		e.add_field(name='Author', value=message.author)
-		e.add_field(name='Author pingable', value=message.author.mention)
-		e.add_field(name='Channel', value=message.channel)
-		if 1024 > len(message.content) > 0:
-			e.add_field(name="Deleted message", value=message.content)
-		elif len(message.content) != 0:
-			e.add_field(name="Deleted message", value=message.content[0:1023])
-			e.add_field(name="Deleted message continued", value=message.content[1024:2000])
-		elif len(message.content) == 0:
-			for i in message.embeds:
-				e.add_field(name="Title", value=i.title)
-				e.add_field(name="Description", value=i.description)
-				e.add_field(name="Timestamp", value=i.timestamp)
-				for x in i.fields:
-					e.add_field(name=x.name, value=x.value)
-				e.add_field(name="Footer", value=i.footer)
-		if message.attachments:
-			e.add_field(name="Attachments", value=", ".join([i.url for i in message.attachments]))
-		with db.Session() as session:
-			messagelogchannel = session.query(Guildmessagelog).filter_by(id=message.guild.id).one_or_none()
-			if messagelogchannel is not None:
-				channel = message.guild.get_channel(messagelogchannel.messagelog_channel)
-				if channel is not None:
-					await channel.send(embed=e)
+    async def on_message_delete(self, message):
+        e = discord.Embed(type='rich')
+        e.title = 'Message Deletion'
+        e.color = 0xFF0000
+        e.add_field(name='Author', value=message.author)
+        e.add_field(name='Author pingable', value=message.author.mention)
+        e.add_field(name='Channel', value=message.channel)
+        if 1024 > len(message.content) > 0:
+            e.add_field(name="Deleted message", value=message.content)
+        elif len(message.content) != 0:
+            e.add_field(name="Deleted message", value=message.content[0:1023])
+            e.add_field(name="Deleted message continued", value=message.content[1024:2000])
+        elif len(message.content) == 0:
+            for i in message.embeds:
+                e.add_field(name="Title", value=i.title)
+                e.add_field(name="Description", value=i.description)
+                e.add_field(name="Timestamp", value=i.timestamp)
+                for x in i.fields:
+                    e.add_field(name=x.name, value=x.value)
+                e.add_field(name="Footer", value=i.footer)
+        if message.attachments:
+            e.add_field(name="Attachments", value=", ".join([i.url for i in message.attachments]))
+        with db.Session() as session:
+            messagelogchannel = session.query(GuildMessageLog).filter_by(id=message.guild.id).one_or_none()
+            if messagelogchannel is not None:
+                channel = message.guild.get_channel(messagelogchannel.messagelog_channel)
+                if channel is not None:
+                    await channel.send(embed=e)
 
-	async def on_message_edit(self, before, after):
-		await self.check_links(after)
-		if before.author.bot: return
-		if after.edited_at is not None or before.edited_at is not None:
-			# There is a reason for this. That reason is that otherwise, an infinite spam loop occurs
-			e = discord.Embed(type='rich')
-			e.title = 'Message Edited'
-			e.color = 0xFF0000
-			e.add_field(name='Author', value=before.author)
-			e.add_field(name='Author pingable', value=before.author.mention)
-			e.add_field(name='Channel', value=before.channel)
-			if 1024 > len(before.content) > 0:
-				e.add_field(name="Old message", value=before.content)
-			elif len(before.content) != 0:
-				e.add_field(name="Old message", value=before.content[0:1023])
-				e.add_field(name="Old message continued", value=before.content[1024:2000])
-			elif len(before.content) == 0 and before.edited_at is not None:
-				for i in before.embeds:
-					e.add_field(name="Title", value=i.title)
-					e.add_field(name="Description", value=i.description)
-					e.add_field(name="Timestamp", value=i.timestamp)
-					for x in i.fields:
-						e.add_field(name=x.name, value=x.value)
-					e.add_field(name="Footer", value=i.footer)
-			if before.attachments:
-				e.add_field(name="Attachments", value=", ".join([i.url for i in message.attachments]))
-			if 0 < len(after.content) < 1024:
-				e.add_field(name="New message", value=after.content)
-			elif len(after.content) != 0:
-				e.add_field(name="New message", value=after.content[0:1023])
-				e.add_field(name="New message continued", value=after.content[1024:2000])
-			elif len(after.content) == 0 and after.edited_at is not None:
-				for i in after.embeds:
-					e.add_field(name="Title", value=i.title)
-					e.add_field(name="Description", value=i.description)
-					e.add_field(name="Timestamp", value=i.timestamp)
-					for x in i.fields:
-						e.add_field(name=x.name, value=x.value)
-			if after.attachments:
-				e.add_field(name="Attachments", value=", ".join([i.url for i in message.attachments]))
-			with db.Session() as session:
-				messagelogchannel = session.query(Guildmessagelog).filter_by(id=before.guild.id).one_or_none()
-				if messagelogchannel is not None:
-					channel = before.guild.get_channel(messagelogchannel.messagelog_channel)
-					if channel is not None:
-						await channel.send(embed=e)
+    async def on_message_edit(self, before, after):
+        await self.check_links(after)
+        if before.author.bot: return
+        if after.edited_at is not None or before.edited_at is not None:
+            # There is a reason for this. That reason is that otherwise, an infinite spam loop occurs
+            e = discord.Embed(type='rich')
+            e.title = 'Message Edited'
+            e.color = 0xFF0000
+            e.add_field(name='Author', value=before.author)
+            e.add_field(name='Author pingable', value=before.author.mention)
+            e.add_field(name='Channel', value=before.channel)
+            if 1024 > len(before.content) > 0:
+                e.add_field(name="Old message", value=before.content)
+            elif len(before.content) != 0:
+                e.add_field(name="Old message", value=before.content[0:1023])
+                e.add_field(name="Old message continued", value=before.content[1024:2000])
+            elif len(before.content) == 0 and before.edited_at is not None:
+                for i in before.embeds:
+                    e.add_field(name="Title", value=i.title)
+                    e.add_field(name="Description", value=i.description)
+                    e.add_field(name="Timestamp", value=i.timestamp)
+                    for x in i.fields:
+                        e.add_field(name=x.name, value=x.value)
+                    e.add_field(name="Footer", value=i.footer)
+            if before.attachments:
+                e.add_field(name="Attachments", value=", ".join([i.url for i in message.attachments]))
+            if 0 < len(after.content) < 1024:
+                e.add_field(name="New message", value=after.content)
+            elif len(after.content) != 0:
+                e.add_field(name="New message", value=after.content[0:1023])
+                e.add_field(name="New message continued", value=after.content[1024:2000])
+            elif len(after.content) == 0 and after.edited_at is not None:
+                for i in after.embeds:
+                    e.add_field(name="Title", value=i.title)
+                    e.add_field(name="Description", value=i.description)
+                    e.add_field(name="Timestamp", value=i.timestamp)
+                    for x in i.fields:
+                        e.add_field(name=x.name, value=x.value)
+            if after.attachments:
+                e.add_field(name="Attachments", value=", ".join([i.url for i in message.attachments]))
+            with db.Session() as session:
+                messagelogchannel = session.query(GuildMessageLog).filter_by(id=before.guild.id).one_or_none()
+                if messagelogchannel is not None:
+                    channel = before.guild.get_channel(messagelogchannel.messagelog_channel)
+                    if channel is not None:
+                        await channel.send(embed=e)
 
-	@command(aliases=["purge"])
-	@has_permissions(manage_messages=True)
-	@bot_has_permissions(manage_messages=True, read_message_history=True)
-	async def prune(self, ctx, num_to_delete: int):
-		"""Bulk delete a set number of messages from the current channel."""
-		await ctx.message.channel.purge(limit=num_to_delete + 1)
-		await ctx.send("Deleted {n} messages under request of {user}".format(n=num_to_delete, user=ctx.message.author.mention), delete_after=5)
+    @command(aliases=["purge"])
+    @has_permissions(manage_messages=True)
+    @bot_has_permissions(manage_messages=True, read_message_history=True)
+    async def prune(self, ctx, num_to_delete: int):
+        """Bulk delete a set number of messages from the current channel."""
+        await ctx.message.channel.purge(limit=num_to_delete + 1)
+        await ctx.send(
+            "Deleted {n} messages under request of {user}".format(n=num_to_delete, user=ctx.message.author.mention),
+            delete_after=5)
 
-	prune.example_usage = """
+    prune.example_usage = """
 	`{prefix}prune 10` - Delete the last 10 messages in the current channel.
 	"""
 
-	@command()
-	@has_permissions(kick_members=True)
-	@bot_has_permissions(manage_roles=True)
-	async def mute(self, ctx, member_mentions: discord.Member, *, reason="No reason provided"):
-		async with ctx.typing(), db.Session() as session:
-			user = session.query(Guildmute).filter_by(id=member_mentions.id, guild=ctx.guild.id).one_or_none()
-			if user is not None:
-				await ctx.send("User is already muted!")
-			else:
-				user = Guildmute(id=member_mentions.id, guild=ctx.guild.id)
-				session.add(user)
-				await self.permoverride(member_mentions, send_messages=False, add_reactions=False)
-				self.bot.loop.create_task(self.punishmenttimer(ctx, reason, member_mentions, lookup=Guildmute, reason=reason))
+    @command()
+    @has_permissions(kick_members=True)
+    @bot_has_permissions(manage_roles=True)
+    async def mute(self, ctx, member_mentions: discord.Member, *, reason="No reason provided"):
+        async with ctx.typing(), db.Session() as session:
+            user = session.query(GuildMute).filter_by(id=member_mentions.id, guild=ctx.guild.id).one_or_none()
+            if user is not None:
+                await ctx.send("User is already muted!")
+            else:
+                user = GuildMute(id=member_mentions.id, guild=ctx.guild.id)
+                session.add(user)
+                await self.perm_override(member_mentions, send_messages=False, add_reactions=False)
+                self.bot.loop.create_task(
+                    self.punishment_timer(ctx, reason, member_mentions, lookup=GuildMute, reason=reason))
 
-	@command()
-	@has_permissions(kick_members=True)
-	@bot_has_permissions(manage_roles=True)
-	async def unmute(self, ctx, member_mentions: discord.Member, reason="No reason provided"):
-		async with ctx.typing(), db.Session() as session:
-			user = session.query(Guildmute).filter_by(id=member_mentions.id, guild=ctx.guild.id).one_or_none()
-			if user is not None:
-				session.delete(user)
-				await self.permoverride(member_mentions, send_messages=None, add_reactions=None)
-				await self.modlogger(ctx=ctx, action="unmuted", target=member_mentions, reason=reason)
-			else:
-				await ctx.send("User is not muted!")
+    @command()
+    @has_permissions(kick_members=True)
+    @bot_has_permissions(manage_roles=True)
+    async def unmute(self, ctx, member_mentions: discord.Member, reason="No reason provided"):
+        async with ctx.typing(), db.Session() as session:
+            user = session.query(GuildMute).filter_by(id=member_mentions.id, guild=ctx.guild.id).one_or_none()
+            if user is not None:
+                session.delete(user)
+                await self.perm_override(member_mentions, send_messages=None, add_reactions=None)
+                await self.mod_logger(ctx=ctx, action="unmuted", target=member_mentions, reason=reason)
+            else:
+                await ctx.send("User is not muted!")
 
-	@command()
-	@has_permissions(kick_members=True)
-	@bot_has_permissions(manage_roles=True)
-	async def deafen(self, ctx, member_mentions: discord.Member, *, reason="No reason provided"):
-		async with ctx.typing(), db.Session() as session:
-			user = session.query(Deafen).filter_by(id=member_mentions.id, guild=ctx.guild.id).one_or_none()
-			if user is not None:
-				await ctx.send("User is already deafened!")
-			else:
-				user = Deafen(id=member_mentions.id, guild=ctx.guild.id, self_inflicted=False)
-				session.add(user)
-				await self.permoverride(member_mentions, read_messages=False)
-				self.bot.loop.create_task(self.punishmenttimer(ctx, reason, member_mentions, lookup=Deafen, reason=reason))
+    @command()
+    @has_permissions(kick_members=True)
+    @bot_has_permissions(manage_roles=True)
+    async def deafen(self, ctx, member_mentions: discord.Member, *, reason="No reason provided"):
+        async with ctx.typing(), db.Session() as session:
+            user = session.query(Deafen).filter_by(id=member_mentions.id, guild=ctx.guild.id).one_or_none()
+            if user is not None:
+                await ctx.send("User is already deafened!")
+            else:
+                user = Deafen(id=member_mentions.id, guild=ctx.guild.id, self_inflicted=False)
+                session.add(user)
+                await self.perm_override(member_mentions, read_messages=False)
+                self.bot.loop.create_task(
+                    self.punishment_timer(ctx, reason, member_mentions, lookup=Deafen, reason=reason))
 
-	@command()
-	@bot_has_permissions(manage_roles=True)
-	async def selfdeafen(self, ctx, timing, *, reason="No reason provided"):
-		async with ctx.typing(), db.Session() as session:
-			user = session.query(Deafen).filter_by(id=ctx.author.id, guild=ctx.guild.id).one_or_none()
-			if user is not None:
-				await ctx.send("You are already deafened!")
-			else:
-				user = Deafen(id=ctx.author.id, guild=ctx.guild.id, self_inflicted=True)
-				session.add(user)
-				await self.permoverride(user=ctx.author, read_messages=False)
-				self.bot.loop.create_task(self.punishmenttimer(ctx, timing, ctx.author, lookup=Deafen, reason=reason))
-	selfdeafen.example_usage = """
+    @command()
+    @bot_has_permissions(manage_roles=True)
+    async def selfdeafen(self, ctx, timing, *, reason="No reason provided"):
+        async with ctx.typing(), db.Session() as session:
+            user = session.query(Deafen).filter_by(id=ctx.author.id, guild=ctx.guild.id).one_or_none()
+            if user is not None:
+                await ctx.send("You are already deafened!")
+            else:
+                user = Deafen(id=ctx.author.id, guild=ctx.guild.id, self_inflicted=True)
+                session.add(user)
+                await self.perm_override(user=ctx.author, read_messages=False)
+                self.bot.loop.create_task(self.punishment_timer(ctx, timing, ctx.author, lookup=Deafen, reason=reason))
+
+    selfdeafen.example_usage = """
 	``[prefix]selfdeafen time (1h5m, both optional) reason``: deafens you if you need to get work done
 	"""
 
-	@command()
-	@has_permissions(kick_members=True)
-	@bot_has_permissions(manage_roles=True)
-	async def undeafen(self, ctx, member_mentions: discord.Member, reason="No reason provided"):
-		async with ctx.typing(), db.Session() as session:
-			user = session.query(Deafen).filter_by(id=member_mentions.id, guild=ctx.guild.id).one_or_none()
-			if user is not None:
-				await self.permoverride(user=member_mentions, read_messages=None)
-				session.delete(user)
-				if user.self_inflicted:
-					reason = "self deafen timer expired"
-				await self.modlogger(ctx=ctx, action="undeafened", target=member_mentions, reason=reason)
-			else:
-				await ctx.send("User is not deafened!")
+    @command()
+    @has_permissions(kick_members=True)
+    @bot_has_permissions(manage_roles=True)
+    async def undeafen(self, ctx, member_mentions: discord.Member, reason="No reason provided"):
+        async with ctx.typing(), db.Session() as session:
+            user = session.query(Deafen).filter_by(id=member_mentions.id, guild=ctx.guild.id).one_or_none()
+            if user is not None:
+                await self.perm_override(user=member_mentions, read_messages=None)
+                session.delete(user)
+                if user.self_inflicted:
+                    reason = "self deafen timer expired"
+                await self.mod_logger(ctx=ctx, action="undeafened", target=member_mentions, reason=reason)
+            else:
+                await ctx.send("User is not deafened!")
 
 
-class Guildmute(db.DatabaseObject):
-	__tablename__ = 'mutes'
-	id = db.Column(db.Integer, primary_key=True)
-	guild = db.Column(db.Integer, primary_key=True)
+class GuildMute(db.DatabaseObject):
+    __tablename__ = 'mutes'
+    id = db.Column(db.Integer, primary_key=True)
+    guild = db.Column(db.Integer, primary_key=True)
 
 
 class Deafen(db.DatabaseObject):
-	__tablename__ = 'deafens'
-	id = db.Column(db.Integer, primary_key=True)
-	guild = db.Column(db.Integer, primary_key=True)
-	self_inflicted = db.Column(db.Boolean)
+    __tablename__ = 'deafens'
+    id = db.Column(db.Integer, primary_key=True)
+    guild = db.Column(db.Integer, primary_key=True)
+    self_inflicted = db.Column(db.Boolean)
 
 
-class Guildmodlog(db.DatabaseObject):
-	__tablename__ = 'modlogconfig'
-	id = db.Column(db.Integer, primary_key=True)
-	name = db.Column(db.String)
-	modlog_channel = db.Column(db.Integer, nullable=True)
+class GuildModLog(db.DatabaseObject):
+    __tablename__ = 'modlogconfig'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String)
+    modlog_channel = db.Column(db.Integer, nullable=True)
 
 
 class MemberRole(db.DatabaseObject):
-	__tablename__ = 'member_roles'
-	id = db.Column(db.Integer, primary_key=True)
-	member_role = db.Column(db.Integer, nullable=True)
+    __tablename__ = 'member_roles'
+    id = db.Column(db.Integer, primary_key=True)
+    member_role = db.Column(db.Integer, nullable=True)
 
 
 class GuildNewMember(db.DatabaseObject):
-	__tablename__ = 'new_members'
-	guild_id = db.Column(db.Integer, primary_key=True)
-	channel_id = db.Column(db.Integer)
-	role_id = db.Column(db.Integer)
-	message = db.Column(db.String)
+    __tablename__ = 'new_members'
+    guild_id = db.Column(db.Integer, primary_key=True)
+    channel_id = db.Column(db.Integer)
+    role_id = db.Column(db.Integer)
+    message = db.Column(db.String)
 
 
-class Guildmemberlog(db.DatabaseObject):
-	__tablename__ = 'memberlogconfig'
-	id = db.Column(db.Integer, primary_key=True)
-	name = db.Column(db.String)
-	memberlog_channel = db.Column(db.Integer)
+class GuildMemberLog(db.DatabaseObject):
+    __tablename__ = 'memberlogconfig'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String)
+    memberlog_channel = db.Column(db.Integer)
 
 
-class Guildmessagelog(db.DatabaseObject):
-	__tablename__ = 'messagelogconfig'
-	id = db.Column(db.Integer, primary_key=True)
-	name = db.Column(db.String)
-	messagelog_channel = db.Column(db.Integer)
+class GuildMessageLog(db.DatabaseObject):
+    __tablename__ = 'messagelogconfig'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String)
+    messagelog_channel = db.Column(db.Integer)
 
 
 class GuildMessageLinks(db.DatabaseObject):
-	__tablename__ = 'guild_msg_links'
-	guild_id = db.Column(db.Integer, primary_key=True)
-	role_id = db.Column(db.Integer, nullable=True)
+    __tablename__ = 'guild_msg_links'
+    guild_id = db.Column(db.Integer, primary_key=True)
+    role_id = db.Column(db.Integer, nullable=True)
 
 
 def setup(bot):
-	bot.add_cog(Moderation(bot))
+    bot.add_cog(Moderation(bot))

--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -176,8 +176,8 @@ class Moderation(Cog):
                 channel=channel_mention.name, role=role_name, message=message))
 
     nmconfig.example_usage = """
-	`{prefix}nmconfig #new_members Member I have read the rules and regulations` - Configures the #new_members channel so if someone types "I have read the rules and regulations" it assigns them the Member role. 
-	"""
+    `{prefix}nmconfig #new_members Member I have read the rules and regulations` - Configures the #new_members channel so if someone types "I have read the rules and regulations" it assigns them the Member role. 
+    """
 
     @command()
     @has_permissions(manage_roles=True)
@@ -231,8 +231,8 @@ class Moderation(Cog):
         await msg.edit(embed=e)
 
     timeout.example_usage = """
-	`{prefix}timeout 60` - prevents sending messages in this channel for 1 minute (60s)
-	"""
+    `{prefix}timeout 60` - prevents sending messages in this channel for 1 minute (60s)
+    """
 
     @command()
     @has_permissions(administrator=True)
@@ -254,13 +254,13 @@ class Moderation(Cog):
         await ctx.send('Member role set as `{}`.'.format(member_role.name))
 
     memberconfig.example_usage = """
-	`{prefix}memberconfig Members` - set a role called "Members" as the member role
-	`{prefix}memberconfig @everyone` - set the default role as the member role
-	`{prefix}memberconfig everyone` - set the default role as the member role (ping-safe)
-	`{prefix}memberconfig @ everyone` - set the default role as the member role (ping-safe)
-	`{prefix}memberconfig @.everyone` - set the default role as the member role (ping-safe)
-	`{prefix}memberconfig @/everyone` - set the default role as the member role (ping-safe)
-	"""
+    `{prefix}memberconfig Members` - set a role called "Members" as the member role
+    `{prefix}memberconfig @everyone` - set the default role as the member role
+    `{prefix}memberconfig everyone` - set the default role as the member role (ping-safe)
+    `{prefix}memberconfig @ everyone` - set the default role as the member role (ping-safe)
+    `{prefix}memberconfig @.everyone` - set the default role as the member role (ping-safe)
+    `{prefix}memberconfig @/everyone` - set the default role as the member role (ping-safe)
+    """
 
     @command()
     @has_permissions(administrator=True)
@@ -283,13 +283,13 @@ class Moderation(Cog):
         await ctx.send(f'Link role set as `{link_role.name}`.')
 
     linkscrubconfig.example_usage = """
-	`{prefix}linkscrubconfig Links` - set a role called "Links" as the link role
-	`{prefix}linkscrubconfig @everyone` - set the default role as the link role
-	`{prefix}linkscrubconfig everyone` - set the default role as the link role (ping-safe)
-	`{prefix}linkscrubconfig @ everyone` - set the default role as the link role (ping-safe)
-	`{prefix}linkscrubconfig @.everyone` - set the default role as the link role (ping-safe)
-	`{prefix}linkscrubconfig @/everyone` - set the default role as the link role (ping-safe)
-	"""
+    `{prefix}linkscrubconfig Links` - set a role called "Links" as the link role
+    `{prefix}linkscrubconfig @everyone` - set the default role as the link role
+    `{prefix}linkscrubconfig everyone` - set the default role as the link role (ping-safe)
+    `{prefix}linkscrubconfig @ everyone` - set the default role as the link role (ping-safe)
+    `{prefix}linkscrubconfig @.everyone` - set the default role as the link role (ping-safe)
+    `{prefix}linkscrubconfig @/everyone` - set the default role as the link role (ping-safe)
+    """
 
     @command()
     @has_permissions(administrator=True)
@@ -434,8 +434,8 @@ class Moderation(Cog):
             delete_after=5)
 
     prune.example_usage = """
-	`{prefix}prune 10` - Delete the last 10 messages in the current channel.
-	"""
+    `{prefix}prune 10` - Delete the last 10 messages in the current channel.
+    """
 
     @command()
     @has_permissions(kick_members=True)
@@ -494,8 +494,8 @@ class Moderation(Cog):
                 self.bot.loop.create_task(self.punishment_timer(ctx, timing, ctx.author, lookup=Deafen, reason=reason))
 
     selfdeafen.example_usage = """
-	``[prefix]selfdeafen time (1h5m, both optional) reason``: deafens you if you need to get work done
-	"""
+    ``[prefix]selfdeafen time (1h5m, both optional) reason``: deafens you if you need to get work done
+    """
 
     @command()
     @has_permissions(kick_members=True)

--- a/dozer/cogs/namegame.py
+++ b/dozer/cogs/namegame.py
@@ -191,13 +191,13 @@ class NameGame(Cog):
                              value="You have 60 seconds to make a pick, or you get skipped and get a strike.")
         game_embed.add_field(name="Shaking Things Up",
                              value="Any team number that ends in a 0 mean that the next player has a wildcard, and can pick any legal team.")
-        game_embed.add_field(name="Pesky Commands", value=f"To start a game, type `{ctx.prefix}ng startround` and mention the players you want to play with. \
-You can add people with `{ctx.prefix}ng addplayer <user_pings>`. \
-When it's your turn, type `{ctx.prefix}ng pick <team> <teamname>` to execute your pick. \
-If you need to skip, typing `{ctx.prefix}ng skip` gives you a strike and skips your turn. \
-You can always do `{ctx.prefix}ng gameinfo` to get the current game status. \
-If you ever need to quit, running `{ctx.prefix}ng drop` removes you from the game. \
-For more detailed command help, run `{ctx.prefix}help ng.`")
+        game_embed.add_field(name="Pesky Commands", value=(f"To start a game, type `{ctx.prefix}ng startround` and mention the players you want to play with. "
+                             f"You can add people with `{ctx.prefix}ng addplayer <user_pings>`. "
+                             f"When it's your turn, type `{ctx.prefix}ng pick <team> <teamname>` to execute your pick. "
+                             f"If you need to skip, typing `{ctx.prefix}ng skip` gives you a strike and skips your turn. "
+                             f"You can always do `{ctx.prefix}ng gameinfo` to get the current game status. "
+                             f"If you ever need to quit, running `{ctx.prefix}ng drop` removes you from the game. "
+                             f"For more detailed command help, run `{ctx.prefix}help ng.`"))
         game_embed.add_field(name="Different Game Modes",
                              value=f"You can play the name game with FTC teams too! To start a game playing with FTC teams, run `{ctx.prefix}ng startround ftc`")
         await ctx.send(embed=game_embed)

--- a/dozer/cogs/namegame.py
+++ b/dozer/cogs/namegame.py
@@ -171,8 +171,8 @@ class NameGame(Cog):
         await self.info.callback(self, ctx)
 
     ng.example_usage = """
-	`{prefix}ng` - show a description on how the robotics team namegame works. 
-	"""
+    `{prefix}ng` - show a description on how the robotics team namegame works. 
+    """
 
     @ng.command()
     @bot_has_permissions(embed_links=True)
@@ -203,15 +203,15 @@ For more detailed command help, run `{ctx.prefix}help ng.`")
         await ctx.send(embed=game_embed)
 
     info.example_usage = """
-	`{prefix}ng help` - show a description on how the robotics team namegame works
-	"""
+    `{prefix}ng help` - show a description on how the robotics team namegame works
+    """
 
     @ng.group(invoke_without_command=True)
     async def config(self, ctx):
         await ctx.send(f"""`{ctx.prefix}ng config` reference:
-				`{ctx.prefix}ng config defaultmode [mode]` - set tbe default game mode used when startround is used with no arguments
-				`{ctx.prefix}ng config setchannel [channel_mention]` - set the channel that games are allowed to be run in
-				`{ctx.prefix}ng config clearsetchannel` - clear the set channel for games""")
+                `{ctx.prefix}ng config defaultmode [mode]` - set tbe default game mode used when startround is used with no arguments
+                `{ctx.prefix}ng config setchannel [channel_mention]` - set the channel that games are allowed to be run in
+                `{ctx.prefix}ng config clearsetchannel` - clear the set channel for games""")
 
     @config.command()
     @has_permissions(manage_guild=True)
@@ -384,8 +384,8 @@ For more detailed command help, run `{ctx.prefix}help ng.`")
         game.turn_task = self.bot.loop.create_task(self.game_turn_countdown(ctx, game))
 
     startround.example_usage = """
-	`{prefix}ng startround frc` - start an FRC namegame session.
-	"""
+    `{prefix}ng startround frc` - start an FRC namegame session.
+    """
 
     @ng.command()
     @game_is_running
@@ -420,8 +420,8 @@ For more detailed command help, run `{ctx.prefix}help ng.`")
             ))
 
     addplayer.example_usage = """
-	`{prefix}ng addplayer @user1, @user2` - add user1 and user2 to the game.
-	"""
+    `{prefix}ng addplayer @user1, @user2` - add user1 and user2 to the game.
+    """
 
     @ng.command()
     @game_is_running
@@ -501,8 +501,8 @@ For more detailed command help, run `{ctx.prefix}help ng.`")
                 game.vote_task = self.bot.loop.create_task(self.game_vote_countdown(ctx, game))
 
     pick.example_usage = """
-	`{prefix}ng pick 254 poofy cheeses` - attempt to guess team 254 with a specified name of "poofy cheeses".
-	"""
+    `{prefix}ng pick 254 poofy cheeses` - attempt to guess team 254 with a specified name of "poofy cheeses".
+    """
 
     @ng.command()
     @game_is_running
@@ -522,8 +522,8 @@ For more detailed command help, run `{ctx.prefix}help ng.`")
                 await self.display_info(ctx, game)
 
     drop.example_usage = """
-	`{prefix}ng drop` - remove the initiator of the command from the current game
-	"""
+    `{prefix}ng drop` - remove the initiator of the command from the current game
+    """
 
     @ng.command()
     @game_is_running
@@ -537,8 +537,8 @@ For more detailed command help, run `{ctx.prefix}help ng.`")
                 await self.skip_player(ctx, game, ctx.author)
 
     skip.example_usage = """
-	`{prefix}ng skip` - skip the current player's turn
-	"""
+    `{prefix}ng skip` - skip the current player's turn
+    """
 
     @ng.command()
     @game_is_running
@@ -548,8 +548,8 @@ For more detailed command help, run `{ctx.prefix}help ng.`")
         await self.display_info(ctx, game)
 
     gameinfo.example_usage = """
-	`{prefix}ng gameinfo` - display info about the currently running game.
-	"""
+    `{prefix}ng gameinfo` - display info about the currently running game.
+    """
 
     @ng.command()
     async def leaderboard(self, ctx, mode: str = None):
@@ -571,8 +571,8 @@ For more detailed command help, run `{ctx.prefix}help ng.`")
             await ctx.send(embed=embed)
 
     leaderboard.example_usage = """
-	`{prefix}ng leaderboard ftc` - display the namegame winning leaderboards for FTC.
-	"""
+    `{prefix}ng leaderboard ftc` - display the namegame winning leaderboards for FTC.
+    """
 
     async def strike(self, ctx, game, player):
         if game.strike(player):

--- a/dozer/cogs/namegame.py
+++ b/dozer/cogs/namegame.py
@@ -1,714 +1,754 @@
-import discord
-import datetime
-import pickle
-import gzip
 import asyncio
-import tbapi
+import gzip
+import pickle
 import traceback
+from collections import OrderedDict
+from functools import wraps
+
+import discord
+import tbapi
+from discord.ext.commands import bot_has_permissions, has_permissions
+from fuzzywuzzy import fuzz
+
+from dozer.bot import logger
 from ._utils import *
 from .. import db
-from discord.ext import commands
-from discord.ext.commands import BadArgument, Group, bot_has_permissions, has_permissions
-from datetime import timedelta
-from collections import OrderedDict
-from fuzzywuzzy import fuzz
-from functools import wraps
-from dozer.bot import logger
 
 SUPPORTED_MODES = ["frc", "ftc"]
+
+
 def keep_alive(func):
-	# keeps the wrapped async function alive; functions must have self and ctx as args
-	@wraps(func)
-	async def wrapper(self, ctx, *args, **kwargs):
-		while True:
-			try:
-				return await func(self, ctx, *args, **kwargs)
-			except Exception as e:
-				# CancelledErrors are normal part of operation, ignore them
-				if isinstance(e, asyncio.CancelledError):
-					return
-				# panic to the console, and to chat
-				logger.error(traceback.format_exc())
-				await ctx.send(f"```Error in game loop:\n{e.__class__.__name__}: {e}```")
-	return wrapper
+    # keeps the wrapped async function alive; functions must have self and ctx as args
+    @wraps(func)
+    async def wrapper(self, ctx, *args, **kwargs):
+        while True:
+            try:
+                return await func(self, ctx, *args, **kwargs)
+            except Exception as e:
+                # CancelledErrors are normal part of operation, ignore them
+                if isinstance(e, asyncio.CancelledError):
+                    return
+                # panic to the console, and to chat
+                logger.error(traceback.format_exc())
+                await ctx.send(f"```Error in game loop:\n{e.__class__.__name__}: {e}```")
+
+    return wrapper
+
 
 def game_is_running(func):
-	@wraps(func)
-	async def wrapper(self, ctx, *args, **kwargs):
+    @wraps(func)
+    async def wrapper(self, ctx, *args, **kwargs):
+        if ctx.channel.id not in self.games:
+            await ctx.send(f"There's not a game going on! Start one with `{ctx.prefix}ng startround`")
+            return
 
-		if ctx.channel.id not in self.games:
-			await ctx.send(f"There's not a game going on! Start one with `{ctx.prefix}ng startround`")
-			return
+        return await func(self, ctx, *args, **kwargs)
 
-		return await func(self, ctx, *args, **kwargs)
-	return wrapper
+    return wrapper
+
 
 class NameGameSession():
-	def __init__(self, mode):
-		self.running = True
-		self.pings_enabled = False
-		self.players = OrderedDict()
-		self.removed_players = []
-		self.picked = []
-		self.mode = mode
-		self.time = 60
-		self.vote_time = -1
-		self.number = 0
-		self.current_player = None
-		self.last_name = ""
-		self.last_team = 0
-		self.state_lock = None
-		self.turn_msg = None
-		self.turn_embed = None
-		self.turn_task = None
-		self.turn_count = 0
+    def __init__(self, mode):
+        self.running = True
+        self.pings_enabled = False
+        self.players = OrderedDict()
+        self.removed_players = []
+        self.picked = []
+        self.mode = mode
+        self.time = 60
+        self.vote_time = -1
+        self.number = 0
+        self.current_player = None
+        self.last_name = ""
+        self.last_team = 0
+        self.state_lock = None
+        self.turn_msg = None
+        self.turn_embed = None
+        self.turn_task = None
+        self.turn_count = 0
 
-		self.pass_tally = 0
-		self.fail_tally = 0
-		
-		self.vote_correct = False
-		self.vote_player = None
-		self.vote_msg = None
-		self.vote_embed = None
-		self.vote_task = None
+        self.pass_tally = 0
+        self.fail_tally = 0
 
-	def create_embed(self, title="", description="", color=discord.Color.blurple(), extra_fields=[], start=False):
-		v = "Starting " if start else "Current "
-		embed = discord.Embed()
-		embed.title = title
-		embed.description = description
-		embed.color = color
-		embed.add_field(name="Players", value=", ".join([p.display_name for p in self.players.keys()]) or "n/a")
-		embed.add_field(name=v+"Player", value=self.current_player)
-		embed.add_field(name=v+"Number", value=self.number or "Wildcard")
-		embed.add_field(name="Time Left", value=self.time)
+        self.vote_correct = False
+        self.vote_player = None
+        self.vote_msg = None
+        self.vote_embed = None
+        self.vote_task = None
 
-		for name, value in extra_fields:
-			embed.add_field(name=name, value=value)
-		return embed
+    def create_embed(self, title="", description="", color=discord.Color.blurple(), extra_fields=[], start=False):
+        v = "Starting " if start else "Current "
+        embed = discord.Embed()
+        embed.title = title
+        embed.description = description
+        embed.color = color
+        embed.add_field(name="Players", value=", ".join([p.display_name for p in self.players.keys()]) or "n/a")
+        embed.add_field(name=v + "Player", value=self.current_player)
+        embed.add_field(name=v + "Number", value=self.number or "Wildcard")
+        embed.add_field(name="Time Left", value=self.time)
 
-	def check_name(self, ctx, team, name):
-		tba_parser = ctx.cog.tba_parser
-		ftc_teams = ctx.cog.ftc_teams
+        for name, value in extra_fields:
+            embed.add_field(name=name, value=value)
+        return embed
 
-		actual_name = ""
+    def check_name(self, ctx, team, name):
+        tba_parser = ctx.cog.tba_parser
+        ftc_teams = ctx.cog.ftc_teams
 
-		if self.mode == "frc":
-			# check for existence
-			team_data = tba_parser.get_team(team)
-			try:
-				getattr(team_data, "Errors")
-			except tbapi.InvalidKeyError:
-				"""There is no error, so do nothing"""
-			else:
-				return -1
-			actual_name = team_data.nickname
-		elif self.mode == "ftc":
-			if team not in ftc_teams:
-				return -1
-			actual_name = ftc_teams[team]
+        actual_name = ""
 
-		self.last_name = actual_name
-		self.last_team = team
-		return fuzz.partial_ratio(actual_name.lower(), name.lower())
+        if self.mode == "frc":
+            # check for existence
+            team_data = tba_parser.get_team(team)
+            try:
+                getattr(team_data, "Errors")
+            except tbapi.InvalidKeyError:
+                """There is no error, so do nothing"""
+            else:
+                return -1
+            actual_name = team_data.nickname
+        elif self.mode == "ftc":
+            if team not in ftc_teams:
+                return -1
+            actual_name = ftc_teams[team]
 
-	def next_turn(self):
-		self.turn_count += 1
-		self.pass_tally = 0
-		self.fail_tally = 0
-		self.time = 60
-			
-		players = list(self.players.keys())
-		# set the current player to the next handle in the list
+        self.last_name = actual_name
+        self.last_team = team
+        return fuzz.partial_ratio(actual_name.lower(), name.lower())
 
-		self.current_player = players[(players.index(self.current_player) + 1) % len(players)]
-		#self._idx = (self._idx + 1) % len(self.players)
+    def next_turn(self):
+        self.turn_count += 1
+        self.pass_tally = 0
+        self.fail_tally = 0
+        self.time = 60
 
-	def strike(self, player):
-		self.players[player] += 1
-		if self.players[player] >= 3 or len(self.players) == 1:
-			self.removed_players.append(player)
-			self.players.pop(player)
-			return True
-		return False
+        players = list(self.players.keys())
+        # set the current player to the next handle in the list
 
-	def check_win(self):
-		return len(self.players) == 1 and self.turn_count > 6
+        self.current_player = players[(players.index(self.current_player) + 1) % len(players)]
 
-	def get_picked(self):
-		return ", ".join(map(str, sorted(self.picked))) or "No Picked Teams"
+    # self._idx = (self._idx + 1) % len(self.players)
+
+    def strike(self, player):
+        self.players[player] += 1
+        if self.players[player] >= 3 or len(self.players) == 1:
+            self.removed_players.append(player)
+            self.players.pop(player)
+            return True
+        return False
+
+    def check_win(self):
+        return len(self.players) == 1 and self.turn_count > 6
+
+    def get_picked(self):
+        return ", ".join(map(str, sorted(self.picked))) or "No Picked Teams"
 
 
 class NameGame(Cog):
-	def __init__(self, bot):
-		super().__init__(bot)
-		with gzip.open("ftc_teams.pickle.gz") as f:
-			raw_teams = pickle.load(f)
-			self.ftc_teams = {team: data['seasons'][0]['name'] for (team, data) in raw_teams.items()}
-		self.games = {}
+    def __init__(self, bot):
+        super().__init__(bot)
+        with gzip.open("ftc_teams.pickle.gz") as f:
+            raw_teams = pickle.load(f)
+            self.ftc_teams = {team: data['seasons'][0]['name'] for (team, data) in raw_teams.items()}
+        self.games = {}
 
-		tba_config = bot.config['tba']
-		self.tba_parser = tbapi.TBAParser(tba_config['key'], cache=False)
+        tba_config = bot.config['tba']
+        self.tba_parser = tbapi.TBAParser(tba_config['key'], cache=False)
 
-	
-	@group(invoke_without_command=True)
-	async def ng(self, ctx):
-		"""Show info about and participate in a robotics team namegame.
-		Run the help command on each of the subcommands for more detailed help.
-		List of subcommands:
-			ng info
-			ng startround
-			ng addplayer
-			ng pick
-			ng drop
-			ng skip
-			ng gameinfo
-		"""
-		await self.info.callback(self, ctx)
-	
-	ng.example_usage = """
+    @group(invoke_without_command=True)
+    async def ng(self, ctx):
+        """Show info about and participate in a robotics team namegame.
+        Run the help command on each of the subcommands for more detailed help.
+        List of subcommands:
+            ng info
+            ng startround
+            ng addplayer
+            ng pick
+            ng drop
+            ng skip
+            ng gameinfo
+        """
+        await self.info.callback(self, ctx)
+
+    ng.example_usage = """
 	`{prefix}ng` - show a description on how the robotics team namegame works. 
 	"""
-	
-	@ng.command()
-	@bot_has_permissions(embed_links=True)
-	async def info(self, ctx):
-		"""Show a description of the robotics team name game and how to play."""
-		game_embed = discord.Embed()
-		game_embed.color = discord.Color.magenta()
-		game_embed.title="How to play"
-		game_embed.description = "This is a very simple little game where players will name a team number and name that starts with the last digit of the last named team. Some more specific rules are below:"
-		game_embed.add_field(name="No Double Picking", value="Only pick teams once.")
-		game_embed.add_field(name="Three Strikes, You're Out!",value="You are only allowed three strikes, which are given by picking out of turn, getting the team name wrong, picking a non existant team, being voted that your pick is incorrect, not picking in time, or picking a already picked team.")
-		game_embed.add_field(name="No Cheatsy Doodles",value="No looking up teams on TBA, TOA, VexDB, or other methods, that's just unfair.")
-		game_embed.add_field(name="Times up!", value="You have 60 seconds to make a pick, or you get skipped and get a strike.")
-		game_embed.add_field(name="Shaking Things Up",value="Any team number that ends in a 0 mean that the next player has a wildcard, and can pick any legal team.")
-		game_embed.add_field(name="Pesky Commands", value=f"To start a game, type `{ctx.prefix}ng startround` and mention the players you want to play with. \
+
+    @ng.command()
+    @bot_has_permissions(embed_links=True)
+    async def info(self, ctx):
+        """Show a description of the robotics team name game and how to play."""
+        game_embed = discord.Embed()
+        game_embed.color = discord.Color.magenta()
+        game_embed.title = "How to play"
+        game_embed.description = "This is a very simple little game where players will name a team number and name that starts with the last digit of the last named team. Some more specific rules are below:"
+        game_embed.add_field(name="No Double Picking", value="Only pick teams once.")
+        game_embed.add_field(name="Three Strikes, You're Out!",
+                             value="You are only allowed three strikes, which are given by picking out of turn, getting the team name wrong, picking a non existant team, being voted that your pick is incorrect, not picking in time, or picking a already picked team.")
+        game_embed.add_field(name="No Cheatsy Doodles",
+                             value="No looking up teams on TBA, TOA, VexDB, or other methods, that's just unfair.")
+        game_embed.add_field(name="Times up!",
+                             value="You have 60 seconds to make a pick, or you get skipped and get a strike.")
+        game_embed.add_field(name="Shaking Things Up",
+                             value="Any team number that ends in a 0 mean that the next player has a wildcard, and can pick any legal team.")
+        game_embed.add_field(name="Pesky Commands", value=f"To start a game, type `{ctx.prefix}ng startround` and mention the players you want to play with. \
 You can add people with `{ctx.prefix}ng addplayer <user_pings>`. \
 When it's your turn, type `{ctx.prefix}ng pick <team> <teamname>` to execute your pick. \
 If you need to skip, typing `{ctx.prefix}ng skip` gives you a strike and skips your turn. \
 You can always do `{ctx.prefix}ng gameinfo` to get the current game status. \
 If you ever need to quit, running `{ctx.prefix}ng drop` removes you from the game. \
 For more detailed command help, run `{ctx.prefix}help ng.`")
-		game_embed.add_field(name="Different Game Modes", value=f"You can play the name game with FTC teams too! To start a game playing with FTC teams, run `{ctx.prefix}ng startround ftc`")
-		await ctx.send(embed=game_embed)
+        game_embed.add_field(name="Different Game Modes",
+                             value=f"You can play the name game with FTC teams too! To start a game playing with FTC teams, run `{ctx.prefix}ng startround ftc`")
+        await ctx.send(embed=game_embed)
 
-	info.example_usage = """
+    info.example_usage = """
 	`{prefix}ng help` - show a description on how the robotics team namegame works
 	"""
-	
-	@ng.group(invoke_without_command=True)
-	async def config(self, ctx):
-		await ctx.send(f"""`{ctx.prefix}ng config` reference:
+
+    @ng.group(invoke_without_command=True)
+    async def config(self, ctx):
+        await ctx.send(f"""`{ctx.prefix}ng config` reference:
 				`{ctx.prefix}ng config defaultmode [mode]` - set tbe default game mode used when startround is used with no arguments
 				`{ctx.prefix}ng config setchannel [channel_mention]` - set the channel that games are allowed to be run in
 				`{ctx.prefix}ng config clearsetchannel` - clear the set channel for games""")
-	@config.command()	
-	@has_permissions(manage_guild=True)
-	async def defaultmode(self, ctx, mode : str = None):
-		with db.Session() as session:
-			config = session.query(NameGameConfig).filter_by(guild_id=ctx.guild.id).one_or_none()
-			if mode is None:
-				mode = SUPPORTED_MODES[0] if config is None else config.mode
-				await ctx.send(f"The current default game mode for this server is `{mode}`")
-			else:
-				if mode not in SUPPORTED_MODES:
-					await ctx.send(f"Game mode `{mode}` not supported! Please pick a mode that is one of: `{', '.join(SUPPORTED_MODES)}`")
-					return
-				if config is None:
-					config = NameGameConfig(guild_id=ctx.guild.id, channel_id=None, mode=mode, pings_enabled=False)
-					session.add(config)
-				else:
-					config.mode = mode
-				await ctx.send(f"Default game mode updated to `{mode}`")
-	@config.command()
-	@has_permissions(manage_guild=True)
-	async def setchannel(self, ctx, channel : discord.TextChannel = None):
-		with db.Session() as session:
-			config = session.query(NameGameConfig).filter_by(guild_id=ctx.guild.id).one_or_none()
-			if channel is None:
-				if config is None or config.channel_id is None:
-					await ctx.send(f"There is no currently set namegame channel.\nTo set a channel, run `{ctx.prefix}ng config setchannel [channel_mention]`")
-				else:
-					await ctx.send(f"The currently set namegame channel is {ctx.guild.get_channel(config.channel_id).mention}.\nTo clear this, run `{ctx.prefix}ng config clearsetchannel`")
-			else:
-				if config is None:
-					config = NameGameConfig(guild_id=ctx.guild.id, channel_id=channel.id, mode=SUPPORTED_MODES[0], pings_enabled=False)
-					session.add(config)
-				else:
-					config.channel_id = channel.id
-				await ctx.send(f"Namegame channel set to {channel.mention}!")
-	@config.command()
-	@has_permissions(manage_guild=True)
-	async def clearsetchannel(self, ctx):
-		with db.Session() as session:
-			config = session.query(NameGameConfig).filter_by(guild_id=ctx.guild.id).one_or_none()
-			if config is not None:
-				config.channel_id = None
-			await ctx.send("Namegame channel cleared!")
 
-	@config.command()	
-	@has_permissions(manage_guild=True)
-	async def setpings(self, ctx, enabled : bool):
-		with db.Session() as session:
-			config = session.query(NameGameConfig).filter_by(guild_id=ctx.guild.id).one_or_none()
-			if config is None:
-				config = NameGameConfig(guild_id=ctx.guild.id, channel_id=None, mode=SUPPORTED_MODES[0], pings_enabled=int(enabled))
-				session.add(config)
-			else:
-				config.pings_enabled = int(enabled)
-			await ctx.send(f"Pings enabled set to `{enabled}`!")
+    @config.command()
+    @has_permissions(manage_guild=True)
+    async def defaultmode(self, ctx, mode: str = None):
+        with db.Session() as session:
+            config = session.query(NameGameConfig).filter_by(guild_id=ctx.guild.id).one_or_none()
+            if mode is None:
+                mode = SUPPORTED_MODES[0] if config is None else config.mode
+                await ctx.send(f"The current default game mode for this server is `{mode}`")
+            else:
+                if mode not in SUPPORTED_MODES:
+                    await ctx.send(
+                        f"Game mode `{mode}` not supported! Please pick a mode that is one of: `{', '.join(SUPPORTED_MODES)}`")
+                    return
+                if config is None:
+                    config = NameGameConfig(guild_id=ctx.guild.id, channel_id=None, mode=mode, pings_enabled=False)
+                    session.add(config)
+                else:
+                    config.mode = mode
+                await ctx.send(f"Default game mode updated to `{mode}`")
 
+    @config.command()
+    @has_permissions(manage_guild=True)
+    async def setchannel(self, ctx, channel: discord.TextChannel = None):
+        with db.Session() as session:
+            config = session.query(NameGameConfig).filter_by(guild_id=ctx.guild.id).one_or_none()
+            if channel is None:
+                if config is None or config.channel_id is None:
+                    await ctx.send(
+                        f"There is no currently set namegame channel.\nTo set a channel, run `{ctx.prefix}ng config setchannel [channel_mention]`")
+                else:
+                    await ctx.send(
+                        f"The currently set namegame channel is {ctx.guild.get_channel(config.channel_id).mention}.\nTo clear this, run `{ctx.prefix}ng config clearsetchannel`")
+            else:
+                if config is None:
+                    config = NameGameConfig(guild_id=ctx.guild.id, channel_id=channel.id, mode=SUPPORTED_MODES[0],
+                                            pings_enabled=False)
+                    session.add(config)
+                else:
+                    config.channel_id = channel.id
+                await ctx.send(f"Namegame channel set to {channel.mention}!")
 
-	@config.command()
-	@has_permissions(manage_guild=True)
-	async def leaderboardedit(self, ctx, mode : str, user : discord.User, wins : int):
-		if mode not in SUPPORTED_MODES:
-			await ctx.send(f"Game mode `{mode}` not supported! Please pick a mode that is one of: `{', '.join(SUPPORTED_MODES)}`")
-			return
-		with db.Session() as session:
-			record = session.query(NameGameLeaderboard).filter_by(game_mode=mode, user_id=user.id).one_or_none()
-			if record is None:
-				await ctx.send("User not on leaderboard!")
-				return
-			record.wins = wins
-			await ctx.send(f"{user.display_name}'s wins now set to: **{wins}**")
+    @config.command()
+    @has_permissions(manage_guild=True)
+    async def clearsetchannel(self, ctx):
+        with db.Session() as session:
+            config = session.query(NameGameConfig).filter_by(guild_id=ctx.guild.id).one_or_none()
+            if config is not None:
+                config.channel_id = None
+            await ctx.send("Namegame channel cleared!")
 
-	@config.command()
-	@has_permissions(manage_guild=True)
-	async def leaderboardclear(self, ctx, mode : str):
-		if mode not in SUPPORTED_MODES:
-			await ctx.send(f"Game mode `{mode}` not supported! Please pick a mode that is one of: `{', '.join(SUPPORTED_MODES)}`")
-			return
-		with db.Session() as session:
-			session.query(NameGameLeaderboard).filter_by(game_mode=mode).delete()
-		await ctx.send(f"Cleared leaderboard for mode {mode}")
+    @config.command()
+    @has_permissions(manage_guild=True)
+    async def setpings(self, ctx, enabled: bool):
+        with db.Session() as session:
+            config = session.query(NameGameConfig).filter_by(guild_id=ctx.guild.id).one_or_none()
+            if config is None:
+                config = NameGameConfig(guild_id=ctx.guild.id, channel_id=None, mode=SUPPORTED_MODES[0],
+                                        pings_enabled=int(enabled))
+                session.add(config)
+            else:
+                config.pings_enabled = int(enabled)
+            await ctx.send(f"Pings enabled set to `{enabled}`!")
 
-	#TODO: configurable time limits, ping on event, etc
-	# MORE TODO:
-	"""
-	fix %ng help (done)
-	fix %ng startround (done)
-	fix the wrong team dialouge (????)
-	add pings
-	i hate bots
-	make %ng addplayer be rhetorical question (done)
-	figure out these stupid turn issues
-	"""
+    @config.command()
+    @has_permissions(manage_guild=True)
+    async def leaderboardedit(self, ctx, mode: str, user: discord.User, wins: int):
+        if mode not in SUPPORTED_MODES:
+            await ctx.send(
+                f"Game mode `{mode}` not supported! Please pick a mode that is one of: `{', '.join(SUPPORTED_MODES)}`")
+            return
+        with db.Session() as session:
+            record = session.query(NameGameLeaderboard).filter_by(game_mode=mode, user_id=user.id).one_or_none()
+            if record is None:
+                await ctx.send("User not on leaderboard!")
+                return
+            record.wins = wins
+            await ctx.send(f"{user.display_name}'s wins now set to: **{wins}**")
 
-	@ng.command()
-	@game_is_running
-	async def unheck(self, ctx):
-		"""
-		Emergency removal of a haywire session. 
-		"""
-		game = self.games[ctx.channel.id]
-		game.running = False
-		try:
-			game.vote_task.cancel()
-		except Exception:
-			pass
-		try:
-			game.turn_task.cancel()
-		except Exception:
-			pass
-		
-		self.games.pop(game)
+    @config.command()
+    @has_permissions(manage_guild=True)
+    async def leaderboardclear(self, ctx, mode: str):
+        if mode not in SUPPORTED_MODES:
+            await ctx.send(
+                f"Game mode `{mode}` not supported! Please pick a mode that is one of: `{', '.join(SUPPORTED_MODES)}`")
+            return
+        with db.Session() as session:
+            session.query(NameGameLeaderboard).filter_by(game_mode=mode).delete()
+        await ctx.send(f"Cleared leaderboard for mode {mode}")
 
-	@ng.command()
-	async def modes(self, ctx):
-		await ctx.send(f"Supported game modes: `{', '.join(SUPPORTED_MODES)}`")
+    # TODO: configurable time limits, ping on event, etc
+    # MORE TODO:
+    """
+    fix %ng help (done)
+    fix %ng startround (done)
+    fix the wrong team dialouge (????)
+    add pings
+    i hate bots
+    make %ng addplayer be rhetorical question (done)
+    figure out these stupid turn issues
+    """
 
-	@ng.command()
-	async def startround(self, ctx, mode : str = None):
-		"""
-		Starts a namegame session.
-		One can select the robotics program by specifying one of "FRC" or "FTC".
-		"""
-		if mode is None or mode.lower() not in SUPPORTED_MODES:
-			with db.Session() as session:
-				config = session.query(NameGameConfig).filter_by(guild_id=ctx.guild.id).one_or_none()
-			mode = SUPPORTED_MODES[0] if config is None else config.mode
-			await ctx.send(f"Unspecified or invalid game mode,  assuming game mode `{mode}`. For a full list of game modes, run `{ctx.prefix}ng modes`")
-		
-		pings_enabled = False
-		with db.Session() as session:
-			config = session.query(NameGameConfig).filter_by(guild_id=ctx.guild.id).one_or_none()
-			if config is not None and config.channel_id is not None and config.channel_id != ctx.channel.id:
-				await ctx.send("Games cannot be started in this channel!")
-				return
-			pings_enabled = (config is not None and config.pings_enabled)
+    @ng.command()
+    @game_is_running
+    async def unheck(self, ctx):
+        """
+        Emergency removal of a haywire session.
+        """
+        game = self.games[ctx.channel.id]
+        game.running = False
+        try:
+            game.vote_task.cancel()
+        except Exception:
+            pass
+        try:
+            game.turn_task.cancel()
+        except Exception:
+            pass
 
-		if ctx.channel.id in self.games:
-			await ctx.send("A game is currently going on! Wait till the players finish up to start again.")
-			return
-		game = NameGameSession(mode.lower())
-		game.state_lock = asyncio.Lock(loop=self.bot.loop)
-		game.pings_enabled = pings_enabled
-		game.players[ctx.author] = 0
-		game.current_player = ctx.author
-		for player in ctx.message.mentions:
-			if player == ctx.author: 
-				continue
-			if player.bot:
-				await ctx.send(f"You can't invite bot users like {player.mention}!")
-				continue
-			game.players[player] = 0
-		await self.send_turn_embed(ctx, game,
-			title=f"{mode.upper()} Name Game", 
-			description="A game has been started! The info about the game is as follows:", 
-			color=discord.Color.green()
-		)
-		await self.notify(ctx, game, f"{game.current_player.mention}, start us off!")
-		#await ctx.send(f"{game.current_player.mention}, start us off!")
-		self.games[ctx.channel.id] = game	
-		game.turn_task = self.bot.loop.create_task(self.game_turn_countdown(ctx, game))
-	startround.example_usage = """
+        self.games.pop(game)
+
+    @ng.command()
+    async def modes(self, ctx):
+        await ctx.send(f"Supported game modes: `{', '.join(SUPPORTED_MODES)}`")
+
+    @ng.command()
+    async def startround(self, ctx, mode: str = None):
+        """
+        Starts a namegame session.
+        One can select the robotics program by specifying one of "FRC" or "FTC".
+        """
+        if mode is None or mode.lower() not in SUPPORTED_MODES:
+            with db.Session() as session:
+                config = session.query(NameGameConfig).filter_by(guild_id=ctx.guild.id).one_or_none()
+            mode = SUPPORTED_MODES[0] if config is None else config.mode
+            await ctx.send(
+                f"Unspecified or invalid game mode,  assuming game mode `{mode}`. For a full list of game modes, run `{ctx.prefix}ng modes`")
+
+        pings_enabled = False
+        with db.Session() as session:
+            config = session.query(NameGameConfig).filter_by(guild_id=ctx.guild.id).one_or_none()
+            if config is not None and config.channel_id is not None and config.channel_id != ctx.channel.id:
+                await ctx.send("Games cannot be started in this channel!")
+                return
+            pings_enabled = (config is not None and config.pings_enabled)
+
+        if ctx.channel.id in self.games:
+            await ctx.send("A game is currently going on! Wait till the players finish up to start again.")
+            return
+        game = NameGameSession(mode.lower())
+        game.state_lock = asyncio.Lock(loop=self.bot.loop)
+        game.pings_enabled = pings_enabled
+        game.players[ctx.author] = 0
+        game.current_player = ctx.author
+        for player in ctx.message.mentions:
+            if player == ctx.author:
+                continue
+            if player.bot:
+                await ctx.send(f"You can't invite bot users like {player.mention}!")
+                continue
+            game.players[player] = 0
+        await self.send_turn_embed(ctx, game,
+                                   title=f"{mode.upper()} Name Game",
+                                   description="A game has been started! The info about the game is as follows:",
+                                   color=discord.Color.green()
+                                   )
+        await self.notify(ctx, game, f"{game.current_player.mention}, start us off!")
+        # await ctx.send(f"{game.current_player.mention}, start us off!")
+        self.games[ctx.channel.id] = game
+        game.turn_task = self.bot.loop.create_task(self.game_turn_countdown(ctx, game))
+
+    startround.example_usage = """
 	`{prefix}ng startround frc` - start an FRC namegame session.
 	"""
 
-	@ng.command()
-	@game_is_running
-	async def addplayer(self, ctx):
-		"""Add players to the current game.
-		Only works if the user is currently playing."""
-		if ctx.channel.id not in self.games:
-			await ctx.send(f"There's not a game going on! Start one with `{ctx.prefix}ng startround`")
-			return
-		game = self.games[ctx.channel.id]
+    @ng.command()
+    @game_is_running
+    async def addplayer(self, ctx):
+        """Add players to the current game.
+        Only works if the user is currently playing."""
+        if ctx.channel.id not in self.games:
+            await ctx.send(f"There's not a game going on! Start one with `{ctx.prefix}ng startround`")
+            return
+        game = self.games[ctx.channel.id]
 
-		with await game.state_lock:
-			added = False
-			players = ctx.message.mentions or [ctx.author]
-			for player in ctx.message.mentions:
-				if player.bot:
-					await ctx.send(f"You can't invite bot users like {player.mention}!")
-					continue
+        with await game.state_lock:
+            added = False
+            players = ctx.message.mentions or [ctx.author]
+            for player in ctx.message.mentions:
+                if player.bot:
+                    await ctx.send(f"You can't invite bot users like {player.mention}!")
+                    continue
 
-				if player in game.removed_players:
-					await ctx.send(f"{player.mention} is already out of the game and can't be added back in.")
-				elif player in game.players:
-					await ctx.send(f"{player.mention} is already in the game!")
-				game.players[player] = 0
-				added = True
+                if player in game.removed_players:
+                    await ctx.send(f"{player.mention} is already out of the game and can't be added back in.")
+                elif player in game.players:
+                    await ctx.send(f"{player.mention} is already in the game!")
+                game.players[player] = 0
+                added = True
 
-			if not added: return
-			await ctx.send(embed=game.create_embed(
-				title="Players have been added to the game.",
-				description="See below for an updated player list.", 
-				color=discord.Color.blurple()
-			))
-	addplayer.example_usage = """
+            if not added: return
+            await ctx.send(embed=game.create_embed(
+                title="Players have been added to the game.",
+                description="See below for an updated player list.",
+                color=discord.Color.blurple()
+            ))
+
+    addplayer.example_usage = """
 	`{prefix}ng addplayer @user1, @user2` - add user1 and user2 to the game.
 	"""
 
-	@ng.command()
-	@game_is_running
-	async def pick(self, ctx, team : int, *, name):
-		"""Attempt to pick a team in a game."""
-		game = self.games[ctx.channel.id]
+    @ng.command()
+    @game_is_running
+    async def pick(self, ctx, team: int, *, name):
+        """Attempt to pick a team in a game."""
+        game = self.games[ctx.channel.id]
 
-		with await game.state_lock:
-			if ctx.author != game.current_player:
-				if ctx.author in game.players:
-					await ctx.send("It's not your turn! You've been given a strike for this behaviour! Don't let it happen again...")
-					await self.strike(ctx, game, ctx.author)
-				else:
-					await ctx.send(f"Let the people playing play! If you want to join, ask one of the people currently playing to run `{ctx.prefix}ng addplayer {ctx.author.display_name}`")
-				return
+        with await game.state_lock:
+            if ctx.author != game.current_player:
+                if ctx.author in game.players:
+                    await ctx.send(
+                        "It's not your turn! You've been given a strike for this behaviour! Don't let it happen again...")
+                    await self.strike(ctx, game, ctx.author)
+                else:
+                    await ctx.send(
+                        f"Let the people playing play! If you want to join, ask one of the people currently playing to run `{ctx.prefix}ng addplayer {ctx.author.display_name}`")
+                return
 
-			if game.time < 0:
-				await ctx.send("Vote on the current team before picking the next!")
-				return
+            if game.time < 0:
+                await ctx.send("Vote on the current team before picking the next!")
+                return
 
-			if game.number != 0 and str(game.number) != str(team)[0]:
-				await self.skip_player(ctx, game, ctx.author, "Your team doesn't start with the correct digit! Strike given, moving onto the next player!")
-				return
-			if team in game.picked:
-				await self.skip_player(ctx, game, ctx.author, "That team has already been picked! You have been skipped and given a strike.")
-				return
+            if game.number != 0 and str(game.number) != str(team)[0]:
+                await self.skip_player(ctx, game, ctx.author,
+                                       "Your team doesn't start with the correct digit! Strike given, moving onto the next player!")
+                return
+            if team in game.picked:
+                await self.skip_player(ctx, game, ctx.author,
+                                       "That team has already been picked! You have been skipped and given a strike.")
+                return
 
-			ratio = game.check_name(ctx, team, name)
-			if ratio == -1:
-				#nonexistant team
-				await self.skip_player(ctx, game, ctx.author, f"Team {team} doesn't exist! Strike given, moving onto the next player!")
-				return
-			if ratio > 60:
-				game.picked.append(team)
-				game.number = game.last_team % 10
-				game.next_turn()
-				game.vote_correct = True
-				game.vote_time = 20
-				game.vote_player = ctx.author
-				await self.send_turn_embed(ctx, game,
-					title="Team correct!",
-					description=f"Team {team} ({game.last_name}) was {ratio}% correct! Moving onto the next player as follows. Click the red X to override this decision.",
-					color=discord.Color.green(),
-					extra_fields=[("Voting Time", game.vote_time)]
-				)
-				await game.turn_msg.add_reaction('❌')
-				await self.notify(ctx, game, f"{game.current_player.mention}, you're up! Current number: {game.number}")
-				game.vote_msg = game.turn_msg
-				game.vote_embed = game.turn_embed
+            ratio = game.check_name(ctx, team, name)
+            if ratio == -1:
+                # nonexistant team
+                await self.skip_player(ctx, game, ctx.author,
+                                       f"Team {team} doesn't exist! Strike given, moving onto the next player!")
+                return
+            if ratio > 60:
+                game.picked.append(team)
+                game.number = game.last_team % 10
+                game.next_turn()
+                game.vote_correct = True
+                game.vote_time = 20
+                game.vote_player = ctx.author
+                await self.send_turn_embed(ctx, game,
+                                           title="Team correct!",
+                                           description=f"Team {team} ({game.last_name}) was {ratio}% correct! Moving onto the next player as follows. Click the red X to override this decision.",
+                                           color=discord.Color.green(),
+                                           extra_fields=[("Voting Time", game.vote_time)]
+                                           )
+                await game.turn_msg.add_reaction('❌')
+                await self.notify(ctx, game, f"{game.current_player.mention}, you're up! Current number: {game.number}")
+                game.vote_msg = game.turn_msg
+                game.vote_embed = game.turn_embed
 
-				# EXTREMELY INCOMPLETE LOL
-				# (not anymore)
-			else:
-				game.time = -1
-				game.vote_time = 60
-				game.vote_player = ctx.author
-				game.vote_correct = False
-				vote_embed = discord.Embed()
-				vote_embed.color = discord.Color.gold()
-				vote_embed.title = "A vote is needed!"
-				vote_embed.description = "A player has made a choice with less than 50% similarity. The details of the pick are below. Click on the two emoji to vote if this is correct or not. A 50% majority of players is required to accept it, otherwise the player will get a strike."
-				vote_embed.add_field(name="Player", value=game.current_player.mention)
-				vote_embed.add_field(name="Team", value=team)
-				vote_embed.add_field(name="Said Name", value=name)
-				vote_embed.add_field(name="Actual Name", value=game.last_name)
-				vote_embed.add_field(name="Similarity", value=f"{ratio}%")
-				vote_embed.add_field(name="Voting Time", value=game.vote_time)
-				game.vote_embed = vote_embed
-				game.vote_msg = await ctx.send(embed=vote_embed)
-				await game.vote_msg.add_reaction('✅')
-				await game.vote_msg.add_reaction('❌')
-				game.vote_task = self.bot.loop.create_task(self.game_vote_countdown(ctx, game))
+            # EXTREMELY INCOMPLETE LOL
+            # (not anymore)
+            else:
+                game.time = -1
+                game.vote_time = 60
+                game.vote_player = ctx.author
+                game.vote_correct = False
+                vote_embed = discord.Embed()
+                vote_embed.color = discord.Color.gold()
+                vote_embed.title = "A vote is needed!"
+                vote_embed.description = "A player has made a choice with less than 50% similarity. The details of the pick are below. Click on the two emoji to vote if this is correct or not. A 50% majority of players is required to accept it, otherwise the player will get a strike."
+                vote_embed.add_field(name="Player", value=game.current_player.mention)
+                vote_embed.add_field(name="Team", value=team)
+                vote_embed.add_field(name="Said Name", value=name)
+                vote_embed.add_field(name="Actual Name", value=game.last_name)
+                vote_embed.add_field(name="Similarity", value=f"{ratio}%")
+                vote_embed.add_field(name="Voting Time", value=game.vote_time)
+                game.vote_embed = vote_embed
+                game.vote_msg = await ctx.send(embed=vote_embed)
+                await game.vote_msg.add_reaction('✅')
+                await game.vote_msg.add_reaction('❌')
+                game.vote_task = self.bot.loop.create_task(self.game_vote_countdown(ctx, game))
 
-
-	pick.example_usage = """
+    pick.example_usage = """
 	`{prefix}ng pick 254 poofy cheeses` - attempt to guess team 254 with a specified name of "poofy cheeses".
 	"""
-	@ng.command()
-	@game_is_running
-	async def drop(self, ctx):
-		"""Drops a player from the current game by eliminating them. Once dropped, they can no longer rejoin."""
-		game = self.games[ctx.channel.id]
-		with await game.state_lock:
-			if ctx.author not in game.players:
-				await ctx.send("You can't leave a game you're not in!")
-				return
-			game.players[ctx.author] = 2
-			if ctx.author == game.current_player:
-				await self.skip_player(ctx, game, ctx.author)
-			else:
-				await self.strike(ctx, game, ctx.author)
-			if game.running:
-				await self.display_info(ctx, game)
-	drop.example_usage = """
+
+    @ng.command()
+    @game_is_running
+    async def drop(self, ctx):
+        """Drops a player from the current game by eliminating them. Once dropped, they can no longer rejoin."""
+        game = self.games[ctx.channel.id]
+        with await game.state_lock:
+            if ctx.author not in game.players:
+                await ctx.send("You can't leave a game you're not in!")
+                return
+            game.players[ctx.author] = 2
+            if ctx.author == game.current_player:
+                await self.skip_player(ctx, game, ctx.author)
+            else:
+                await self.strike(ctx, game, ctx.author)
+            if game.running:
+                await self.display_info(ctx, game)
+
+    drop.example_usage = """
 	`{prefix}ng drop` - remove the initiator of the command from the current game
 	"""
-	@ng.command()
-	@game_is_running
-	async def skip(self, ctx):
-		"""Skips the current player if the player wishes to forfeit their turn."""
-		game = self.games[ctx.channel.id]
-		with await game.state_lock:
-			if ctx.author != game.current_player:
-				await ctx.send("It's not your turn! Only the current player can skip their turn!")
-			else:
-				await self.skip_player(ctx, game, ctx.author)
-	skip.example_usage = """
+
+    @ng.command()
+    @game_is_running
+    async def skip(self, ctx):
+        """Skips the current player if the player wishes to forfeit their turn."""
+        game = self.games[ctx.channel.id]
+        with await game.state_lock:
+            if ctx.author != game.current_player:
+                await ctx.send("It's not your turn! Only the current player can skip their turn!")
+            else:
+                await self.skip_player(ctx, game, ctx.author)
+
+    skip.example_usage = """
 	`{prefix}ng skip` - skip the current player's turn
 	"""
 
-	@ng.command()
-	@game_is_running
-	async def gameinfo(self, ctx):
-		"""Display info about the currently running game."""
-		game = self.games[ctx.channel.id]
-		await self.display_info(ctx, game)
+    @ng.command()
+    @game_is_running
+    async def gameinfo(self, ctx):
+        """Display info about the currently running game."""
+        game = self.games[ctx.channel.id]
+        await self.display_info(ctx, game)
 
-	gameinfo.example_usage = """
+    gameinfo.example_usage = """
 	`{prefix}ng gameinfo` - display info about the currently running game.
 	"""
-	
-	@ng.command()
-	async def leaderboard(self, ctx, mode : str = None):
-		"""Display top numbers of wins for the specified game mode"""
-		if mode is None:
-			with db.Session() as session:
-				config = session.query(NameGameConfig).filter_by(guild_id=ctx.guild.id).one_or_none()
-			mode = SUPPORTED_MODES[0] if config is None else config.mode
-		if mode not in SUPPORTED_MODES:
-			await ctx.send(f"Game mode `{mode}` not supported! Please pick a mode that is one of: `{', '.join(SUPPORTED_MODES)}`")
-			return
-		with db.Session() as session:
-			leaderboard = sorted(session.query(NameGameLeaderboard).filter_by(game_mode=mode).all(), key=lambda i: i.wins, reverse=True)[:10]
-			embed = discord.Embed(color=discord.Color.gold(), title=f"{mode.upper()} Name Game Leaderboard")
-			for idx, entry in enumerate(leaderboard, 1):
-				embed.add_field(name=f"#{idx}: {ctx.bot.get_user(entry.user_id).display_name}", value=entry.wins)
-			await ctx.send(embed=embed)
-	leaderboard.example_usage = """
+
+    @ng.command()
+    async def leaderboard(self, ctx, mode: str = None):
+        """Display top numbers of wins for the specified game mode"""
+        if mode is None:
+            with db.Session() as session:
+                config = session.query(NameGameConfig).filter_by(guild_id=ctx.guild.id).one_or_none()
+            mode = SUPPORTED_MODES[0] if config is None else config.mode
+        if mode not in SUPPORTED_MODES:
+            await ctx.send(
+                f"Game mode `{mode}` not supported! Please pick a mode that is one of: `{', '.join(SUPPORTED_MODES)}`")
+            return
+        with db.Session() as session:
+            leaderboard = sorted(session.query(NameGameLeaderboard).filter_by(game_mode=mode).all(),
+                                 key=lambda i: i.wins, reverse=True)[:10]
+            embed = discord.Embed(color=discord.Color.gold(), title=f"{mode.upper()} Name Game Leaderboard")
+            for idx, entry in enumerate(leaderboard, 1):
+                embed.add_field(name=f"#{idx}: {ctx.bot.get_user(entry.user_id).display_name}", value=entry.wins)
+            await ctx.send(embed=embed)
+
+    leaderboard.example_usage = """
 	`{prefix}ng leaderboard ftc` - display the namegame winning leaderboards for FTC.
 	"""
 
-	async def strike(self, ctx, game, player):
-		if game.strike(player):
-			await ctx.send(f"Player {player.mention} is ELIMINATED!")
-		if len(game.players) == 0 or game.turn_count <= 6:
-			await ctx.send("Game disbanded, no winner called!")
-			game.running = False
-		if game.check_win():
-			# winning condition
-			winner = list(game.players.keys())[0]
-			with db.Session() as session:
-				record = session.query(NameGameLeaderboard).filter_by(user_id=winner.id, game_mode=game.mode).one_or_none()
-				if record is None:
-					record = NameGameLeaderboard(user_id=winner.id, wins=1, game_mode=game.mode)
-					session.add(record)
-				else:
-					record.wins += 1
-			win_embed = discord.Embed()
-			win_embed.color = discord.Color.gold()
-			win_embed.title = "We have a winner!"
-			win_embed.add_field(name="Winning Player", value=winner)
-			win_embed.add_field(name="Wins Total", value=record.wins)
-			win_embed.add_field(name="Teams Picked", value=game.get_picked())
-			await ctx.send(embed=win_embed)
+    async def strike(self, ctx, game, player):
+        if game.strike(player):
+            await ctx.send(f"Player {player.mention} is ELIMINATED!")
+        if len(game.players) == 0 or game.turn_count <= 6:
+            await ctx.send("Game disbanded, no winner called!")
+            game.running = False
+        if game.check_win():
+            # winning condition
+            winner = list(game.players.keys())[0]
+            with db.Session() as session:
+                record = session.query(NameGameLeaderboard).filter_by(user_id=winner.id,
+                                                                      game_mode=game.mode).one_or_none()
+                if record is None:
+                    record = NameGameLeaderboard(user_id=winner.id, wins=1, game_mode=game.mode)
+                    session.add(record)
+                else:
+                    record.wins += 1
+            win_embed = discord.Embed()
+            win_embed.color = discord.Color.gold()
+            win_embed.title = "We have a winner!"
+            win_embed.add_field(name="Winning Player", value=winner)
+            win_embed.add_field(name="Wins Total", value=record.wins)
+            win_embed.add_field(name="Teams Picked", value=game.get_picked())
+            await ctx.send(embed=win_embed)
 
-			game.running = False
+            game.running = False
 
-		if not game.running:
-			self.games.pop(ctx.channel.id)
-	
-	async def display_info(self, ctx, game):
-		info_embed = discord.Embed(title="Current Game Info", color=discord.Color.blue())
-		info_embed.add_field(name="Game Type", value=game.mode.upper())
-		info_embed.add_field(
-				name="Strikes",
-				value="\n".join([f"{player.display_name}: {strikes}" for player, strikes in game.players.items()])
-		)
-		info_embed.add_field(name="Current Player", value=game.current_player)
-		info_embed.add_field(name="Current Number", value=game.number or "Wildcard")
-		info_embed.add_field(name="Time Left", value=game.time)
-		info_embed.add_field(name="Teams Picked", value=game.get_picked())
-		await ctx.send(embed=info_embed)
+        if not game.running:
+            self.games.pop(ctx.channel.id)
 
-	async def skip_player(self, ctx, game, player, msg=None):
-		if msg is not None:
-			await ctx.send(msg)
-		game.vote_time = -1
-		game.next_turn()
-		await self.send_turn_embed(ctx, game,
-			title=f"Player {player.display_name} was skipped and now has {game.players[player]+1} strike(s)!",
-			color=discord.Color.red()
-		)
-		if player != game.current_player:
-			await self.notify(ctx, game, f"{game.current_player.mention}, you're up! Current number: {game.number}")
-		await self.strike(ctx, game, player)
+    async def display_info(self, ctx, game):
+        info_embed = discord.Embed(title="Current Game Info", color=discord.Color.blue())
+        info_embed.add_field(name="Game Type", value=game.mode.upper())
+        info_embed.add_field(
+            name="Strikes",
+            value="\n".join([f"{player.display_name}: {strikes}" for player, strikes in game.players.items()])
+        )
+        info_embed.add_field(name="Current Player", value=game.current_player)
+        info_embed.add_field(name="Current Number", value=game.number or "Wildcard")
+        info_embed.add_field(name="Time Left", value=game.time)
+        info_embed.add_field(name="Teams Picked", value=game.get_picked())
+        await ctx.send(embed=info_embed)
 
-	# send an embed that starts a new turn
-	async def send_turn_embed(self, ctx, game, **kwargs):
-		game.turn_embed = game.create_embed(**kwargs)
-		game.turn_msg = await ctx.send(embed=game.turn_embed)
-	
-	async def notify(self, ctx, game, msg):
-		if game.pings_enabled:
-			await ctx.send(msg)
+    async def skip_player(self, ctx, game, player, msg=None):
+        if msg is not None:
+            await ctx.send(msg)
+        game.vote_time = -1
+        game.next_turn()
+        await self.send_turn_embed(ctx, game,
+                                   title=f"Player {player.display_name} was skipped and now has {game.players[player]+1} strike(s)!",
+                                   color=discord.Color.red()
+                                   )
+        if player != game.current_player:
+            await self.notify(ctx, game, f"{game.current_player.mention}, you're up! Current number: {game.number}")
+        await self.strike(ctx, game, player)
 
-	async def on_reaction_add(self, reaction, user):
-		if reaction.message.channel.id not in self.games:
-			return
-		game = self.games[reaction.message.channel.id]
-		with await game.state_lock:	
-			if game.vote_msg is None or game.vote_time <= 0:
-				return
-			self._on_reaction(game, reaction, user, 1)
-			
-			# also handle voting logic
-			ctx = await self.bot.get_context(reaction.message)
-			if game.vote_correct:
-				if game.fail_tally > .5 * len(game.players):
-					await ctx.send(f"The decision was overruled! Player {game.vote_player.mention} is given a strike!")
-					await self.strike(ctx, game, game.vote_player)
-					game.vote_time = -1
-			else:
-				if game.pass_tally >= .5 * len(game.players):
-					game.picked.append(game.last_team)
-					game.number = game.last_team % 10
-					game.next_turn()
-					await self.send_turn_embed(ctx, game,
-						title="Team correct!",
-						description=f"Team {game.last_team} ({game.last_name}) was correct! Moving onto the next player as follows.",
-						color=discord.Color.green(),
-					)
-					await self.notify(ctx, game, f"{game.current_player.mention}, you're up! Current number: {game.number}")
-					game.vote_time = -1
-				elif game.fail_tally >= .5 * len(game.players):
-					await ctx.send(f"Team {game.last_team} was guessed wrong! Strike given to the responsible player and player is skipped.")
-					await self.skip_player(ctx, game, game.current_player)
-					game.vote_time = -1
+    # send an embed that starts a new turn
+    async def send_turn_embed(self, ctx, game, **kwargs):
+        game.turn_embed = game.create_embed(**kwargs)
+        game.turn_msg = await ctx.send(embed=game.turn_embed)
 
-	async def on_reaction_remove(self, reaction, user):
-		if reaction.message.channel.id not in self.games:
-			return
-		game = self.games[reaction.message.channel.id]
+    async def notify(self, ctx, game, msg):
+        if game.pings_enabled:
+            await ctx.send(msg)
 
-		with await game.state_lock:
-			if game.vote_msg is None or game.vote_time <= 0:
-				return
-			self._on_reaction(game, reaction, user, -1)
-		
-	def _on_reaction(self, game, reaction, user, inc):
-		# as they say, don't repeat yourself
-		# also, as this is just manipulating memory, it's not async
+    async def on_reaction_add(self, reaction, user):
+        if reaction.message.channel.id not in self.games:
+            return
+        game = self.games[reaction.message.channel.id]
+        with await game.state_lock:
+            if game.vote_msg is None or game.vote_time <= 0:
+                return
+            self._on_reaction(game, reaction, user, 1)
 
-		if reaction.message.id == game.vote_msg.id and user in game.players:
-			if reaction.emoji == '❌':
-				game.fail_tally += inc
-			
-			if reaction.emoji == '✅':
-				game.pass_tally += inc
-		return game
-	
-	@keep_alive
-	async def game_turn_countdown(self, ctx, game):
-		await asyncio.sleep(1)
-		with await game.state_lock:
-			if not game.running:
-				return
-			if game.time > 0:
-				game.time -= 1
-				game.turn_embed.set_field_at(3, name="Time Left", value=game.time)
+            # also handle voting logic
+            ctx = await self.bot.get_context(reaction.message)
+            if game.vote_correct:
+                if game.fail_tally > .5 * len(game.players):
+                    await ctx.send(f"The decision was overruled! Player {game.vote_player.mention} is given a strike!")
+                    await self.strike(ctx, game, game.vote_player)
+                    game.vote_time = -1
+            else:
+                if game.pass_tally >= .5 * len(game.players):
+                    game.picked.append(game.last_team)
+                    game.number = game.last_team % 10
+                    game.next_turn()
+                    await self.send_turn_embed(ctx, game,
+                                               title="Team correct!",
+                                               description=f"Team {game.last_team} ({game.last_name}) was correct! Moving onto the next player as follows.",
+                                               color=discord.Color.green(),
+                                               )
+                    await self.notify(ctx, game,
+                                      f"{game.current_player.mention}, you're up! Current number: {game.number}")
+                    game.vote_time = -1
+                elif game.fail_tally >= .5 * len(game.players):
+                    await ctx.send(
+                        f"Team {game.last_team} was guessed wrong! Strike given to the responsible player and player is skipped.")
+                    await self.skip_player(ctx, game, game.current_player)
+                    game.vote_time = -1
 
-			if game.vote_time > 0 and game.vote_correct:
-				game.vote_time -= 1
-				game.turn_embed.set_field_at(4, name="Voting Time", value=game.vote_time)
-				
-			if game.time % 5 == 0:
-				await game.turn_msg.edit(embed=game.turn_embed)
+    async def on_reaction_remove(self, reaction, user):
+        if reaction.message.channel.id not in self.games:
+            return
+        game = self.games[reaction.message.channel.id]
 
-			if game.time == 0:
-				await self.skip_player(ctx, game, game.current_player)
-			game.turn_task = self.bot.loop.create_task(self.game_turn_countdown(ctx, game))
+        with await game.state_lock:
+            if game.vote_msg is None or game.vote_time <= 0:
+                return
+            self._on_reaction(game, reaction, user, -1)
 
-		
-	@keep_alive	
-	async def game_vote_countdown(self, ctx, game):
-		await asyncio.sleep(1)
-		with await game.state_lock:
-			if not (game.running and not game.vote_correct and game.vote_embed and game.vote_time > 0):
-				return
-			game.vote_time -= 1
-			game.vote_embed.set_field_at(5, name="Voting Time", value=game.vote_time)
-			if game.vote_time % 5 == 0:
-				await game.vote_msg.edit(embed=game.vote_embed)
-			if game.vote_time == 0:
-				await ctx.send("The vote did not reach 50% in favor or in failure, so the responsible player is given a strike and skipped.")
-				await self.skip_player(ctx, game, game.current_player)
+    def _on_reaction(self, game, reaction, user, inc):
+        # as they say, don't repeat yourself
+        # also, as this is just manipulating memory, it's not async
 
-			game.vote_task = self.bot.loop.create_task(self.game_vote_countdown(ctx, game))
+        if reaction.message.id == game.vote_msg.id and user in game.players:
+            if reaction.emoji == '❌':
+                game.fail_tally += inc
+
+            if reaction.emoji == '✅':
+                game.pass_tally += inc
+        return game
+
+    @keep_alive
+    async def game_turn_countdown(self, ctx, game):
+        await asyncio.sleep(1)
+        with await game.state_lock:
+            if not game.running:
+                return
+            if game.time > 0:
+                game.time -= 1
+                game.turn_embed.set_field_at(3, name="Time Left", value=game.time)
+
+            if game.vote_time > 0 and game.vote_correct:
+                game.vote_time -= 1
+                game.turn_embed.set_field_at(4, name="Voting Time", value=game.vote_time)
+
+            if game.time % 5 == 0:
+                await game.turn_msg.edit(embed=game.turn_embed)
+
+            if game.time == 0:
+                await self.skip_player(ctx, game, game.current_player)
+            game.turn_task = self.bot.loop.create_task(self.game_turn_countdown(ctx, game))
+
+    @keep_alive
+    async def game_vote_countdown(self, ctx, game):
+        await asyncio.sleep(1)
+        with await game.state_lock:
+            if not (game.running and not game.vote_correct and game.vote_embed and game.vote_time > 0):
+                return
+            game.vote_time -= 1
+            game.vote_embed.set_field_at(5, name="Voting Time", value=game.vote_time)
+            if game.vote_time % 5 == 0:
+                await game.vote_msg.edit(embed=game.vote_embed)
+            if game.vote_time == 0:
+                await ctx.send(
+                    "The vote did not reach 50% in favor or in failure, so the responsible player is given a strike and skipped.")
+                await self.skip_player(ctx, game, game.current_player)
+
+            game.vote_task = self.bot.loop.create_task(self.game_vote_countdown(ctx, game))
+
+
 class NameGameConfig(db.DatabaseObject):
-	__tablename__ = "namegame_config"
-	guild_id = db.Column(db.Integer, primary_key=True)
-	channel_id = db.Column(db.Integer, nullable=True)
-	mode = db.Column(db.String)
-	pings_enabled = db.Column(db.Integer)
+    __tablename__ = "namegame_config"
+    guild_id = db.Column(db.Integer, primary_key=True)
+    channel_id = db.Column(db.Integer, nullable=True)
+    mode = db.Column(db.String)
+    pings_enabled = db.Column(db.Integer)
+
 
 class NameGameLeaderboard(db.DatabaseObject):
-	__tablename__ = "namegame_leaderboard"
-	user_id = db.Column(db.Integer, primary_key=True)
-	wins = db.Column(db.Integer)
-	game_mode = db.Column(db.String)
+    __tablename__ = "namegame_leaderboard"
+    user_id = db.Column(db.Integer, primary_key=True)
+    wins = db.Column(db.Integer)
+    game_mode = db.Column(db.String)
+
+
 def setup(bot):
-	bot.add_cog(NameGame(bot))
+    bot.add_cog(NameGame(bot))

--- a/dozer/cogs/roles.py
+++ b/dozer/cogs/roles.py
@@ -1,309 +1,337 @@
-import discord, discord.utils
+import discord
+import discord.utils
 from discord.ext.commands import bot_has_permissions, cooldown, BucketType, has_permissions, BadArgument
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
-from .. import db
+
 from ._utils import *
+from .. import db
+
 
 class Roles(Cog):
-	"""Commands for role management."""
-	async def on_member_join(self, member):
-		me = member.guild.me
-		top_restoreable = me.top_role.position if me.guild_permissions.manage_roles else 0
-		with db.Session() as session:
-			restore = session.query(MissingMember).filter_by(guild_id=member.guild.id, member_id=member.id).one_or_none()
-			if restore is None:
-				return # New member - nothing to restore
-			
-			valid, cant_give, missing = set(), set(), set()
-			role_ids = {role.id: role for role in member.guild.roles}
-			for missing_role in restore.missing_roles:
-				role = role_ids.get(missing_role.role_id)
-				if role is None: # Role with that ID does not exist
-					missing.add(missing_role.role_name)
-				elif role.position > top_restoreable:
-					cant_give.add(role.name)
-				else:
-					valid.add(role)
-			
-			session.delete(restore) # Not missing anymore - remove the record to free up the primary key
-		
-		await member.add_roles(*valid)
-		if not missing and not cant_give:
-			return
-		
-		e = discord.Embed(title='Welcome back to the {} server, {}!'.format(member.guild.name, member), color=discord.Color.blue())
-		if missing:
-			e.add_field(name='I couldn\'t restore these roles, as they don\'t exist.', value='\n'.join(sorted(missing)))
-		if cant_give:
-			e.add_field(name='I couldn\'t restore these roles, as I don\'t have permission.', value='\n'.join(sorted(cant_give)))
-		
-		send_perms = discord.Permissions()
-		send_perms.update(send_messages=True, embed_links=True)
-		try:
-			dest = next(channel for channel in member.guild.text_channels if channel.permissions_for(me) >= send_perms)
-		except StopIteration:
-			dest = await member.guild.owner.create_dm()
-		
-		await dest.send(embed=e)
-	
-	async def on_member_remove(self, member):
-		guild_id = member.guild.id
-		member_id = member.id
-		with db.Session() as session:
-			db_member = MissingMember(guild_id=guild_id, member_id=member_id)
-			session.add(db_member)
-			for role in member.roles[1:]: # Exclude the @everyone role
-				db_member.missing_roles.append(MissingRole(role_id=role.id, role_name=role.name))
-	
-	@group(invoke_without_command=True)
-	@bot_has_permissions(manage_roles=True)
-	async def giveme(self, ctx, *, roles):
-		"""Give you one or more giveable roles, separated by commas."""
-		norm_names = [self.normalize(name) for name in roles.split(',')]
-		with db.Session() as session:
-			giveable_ids = [tup[0] for tup in session.query(GiveableRole.id).filter(GiveableRole.guild_id == ctx.guild.id, GiveableRole.norm_name.in_(norm_names)).all()]
-			valid = set(role for role in ctx.guild.roles if role.id in giveable_ids)
-		
-		already_have = valid & set(ctx.author.roles)
-		given = valid - already_have
-		await ctx.author.add_roles(*given)
-		
-		e = discord.Embed(color=discord.Color.blue())
-		if given:
-			given_names = sorted((role.name for role in given), key=str.casefold)
-			e.add_field(name='Gave you {} role(s)!'.format(len(given)), value='\n'.join(given_names), inline=False)
-		if already_have:
-			already_have_names = sorted((role.name for role in already_have), key=str.casefold)
-			e.add_field(name='You already have {} role(s)!'.format(len(already_have)), value='\n'.join(already_have_names), inline=False)
-		extra = len(norm_names) - len(valid)
-		if extra > 0:
-			e.add_field(name='{} role(s) could not be found!'.format(extra), value='Use `{0.prefix}{0.invoked_with} list` to find valid giveable roles!'.format(ctx), inline=False)
-		await ctx.send(embed=e)
-	
-	giveme.example_usage = """
+    """Commands for role management."""
+
+    async def on_member_join(self, member):
+        me = member.guild.me
+        top_restorable = me.top_role.position if me.guild_permissions.manage_roles else 0
+        with db.Session() as session:
+            restore = session.query(MissingMember).filter_by(guild_id=member.guild.id,
+                                                             member_id=member.id).one_or_none()
+            if restore is None:
+                return  # New member - nothing to restore
+
+            valid, cant_give, missing = set(), set(), set()
+            role_ids = {role.id: role for role in member.guild.roles}
+            for missing_role in restore.missing_roles:
+                role = role_ids.get(missing_role.role_id)
+                if role is None:  # Role with that ID does not exist
+                    missing.add(missing_role.role_name)
+                elif role.position > top_restorable:
+                    cant_give.add(role.name)
+                else:
+                    valid.add(role)
+
+            session.delete(restore)  # Not missing anymore - remove the record to free up the primary key
+
+        await member.add_roles(*valid)
+        if not missing and not cant_give:
+            return
+
+        e = discord.Embed(title='Welcome back to the {} server, {}!'.format(member.guild.name, member),
+                          color=discord.Color.blue())
+        if missing:
+            e.add_field(name='I couldn\'t restore these roles, as they don\'t exist.', value='\n'.join(sorted(missing)))
+        if cant_give:
+            e.add_field(name='I couldn\'t restore these roles, as I don\'t have permission.',
+                        value='\n'.join(sorted(cant_give)))
+
+        send_perms = discord.Permissions()
+        send_perms.update(send_messages=True, embed_links=True)
+        try:
+            dest = next(channel for channel in member.guild.text_channels if channel.permissions_for(me) >= send_perms)
+        except StopIteration:
+            dest = await member.guild.owner.create_dm()
+
+        await dest.send(embed=e)
+
+    async def on_member_remove(self, member):
+        guild_id = member.guild.id
+        member_id = member.id
+        with db.Session() as session:
+            db_member = MissingMember(guild_id=guild_id, member_id=member_id)
+            session.add(db_member)
+            for role in member.roles[1:]:  # Exclude the @everyone role
+                db_member.missing_roles.append(MissingRole(role_id=role.id, role_name=role.name))
+
+    @group(invoke_without_command=True)
+    @bot_has_permissions(manage_roles=True)
+    async def giveme(self, ctx, *, roles):
+        """Give you one or more giveable roles, separated by commas."""
+        norm_names = [self.normalize(name) for name in roles.split(',')]
+        with db.Session() as session:
+            giveable_ids = [tup[0] for tup in
+                            session.query(GiveableRole.id).filter(GiveableRole.guild_id == ctx.guild.id,
+                                                                  GiveableRole.norm_name.in_(norm_names)).all()]
+            valid = set(role for role in ctx.guild.roles if role.id in giveable_ids)
+
+        already_have = valid & set(ctx.author.roles)
+        given = valid - already_have
+        await ctx.author.add_roles(*given)
+
+        e = discord.Embed(color=discord.Color.blue())
+        if given:
+            given_names = sorted((role.name for role in given), key=str.casefold)
+            e.add_field(name='Gave you {} role(s)!'.format(len(given)), value='\n'.join(given_names), inline=False)
+        if already_have:
+            already_have_names = sorted((role.name for role in already_have), key=str.casefold)
+            e.add_field(name='You already have {} role(s)!'.format(len(already_have)),
+                        value='\n'.join(already_have_names), inline=False)
+        extra = len(norm_names) - len(valid)
+        if extra > 0:
+            e.add_field(name='{} role(s) could not be found!'.format(extra),
+                        value='Use `{0.prefix}{0.invoked_with} list` to find valid giveable roles!'.format(ctx),
+                        inline=False)
+        await ctx.send(embed=e)
+
+    giveme.example_usage = """
 	`{prefix}giveme Java` - gives you the role called Java, if it exists
 	`{prefix}giveme Java, Python` - gives you the roles called Java and Python, if they exist
 	"""
-	
-	@giveme.command()
-	@bot_has_permissions(manage_roles=True)
-	@has_permissions(manage_guild=True)
-	async def add(self, ctx, *, name):
-		"""Makes an existing role giveable, or creates one if it doesn't exist. Name must not contain commas.
-		Similar to create, but will use an existing role if one exists."""
-		if ',' in name:
-			raise BadArgument('giveable role names must not contain commas!')
-		norm_name = self.normalize(name)
-		with db.Session() as session:
-			settings = session.query(GuildSettings).filter_by(id=ctx.guild.id).one_or_none()
-			if settings is None:
-				settings = GuildSettings(id=ctx.guild.id)
-				session.add(settings)
-			if norm_name in (giveable.norm_name for giveable in settings.giveable_roles):
-				raise BadArgument('that role already exists and is giveable!')
-			candidates = [role for role in ctx.guild.roles if self.normalize(role.name) == norm_name]
-			
-			if not candidates:
-				role = await ctx.guild.create_role(name=name, reason='Giveable role created by {}'.format(ctx.author))
-			elif len(candidates) == 1:
-				role = candidates[0]
-			else:
-				raise BadArgument('{} roles with that name exist!'.format(len(candidates)))
-			settings.giveable_roles.append(GiveableRole.from_role(role))
-		await ctx.send('Role "{0}" added! Use `{1}{2} {0}` to get it!'.format(role.name, ctx.prefix, ctx.command.parent))
-	
-	add.example_usage = """
+
+    @giveme.command()
+    @bot_has_permissions(manage_roles=True)
+    @has_permissions(manage_guild=True)
+    async def add(self, ctx, *, name):
+        """Makes an existing role giveable, or creates one if it doesn't exist. Name must not contain commas.
+        Similar to create, but will use an existing role if one exists."""
+        if ',' in name:
+            raise BadArgument('giveable role names must not contain commas!')
+        norm_name = self.normalize(name)
+        with db.Session() as session:
+            settings = session.query(GuildSettings).filter_by(id=ctx.guild.id).one_or_none()
+            if settings is None:
+                settings = GuildSettings(id=ctx.guild.id)
+                session.add(settings)
+            if norm_name in (giveable.norm_name for giveable in settings.giveable_roles):
+                raise BadArgument('that role already exists and is giveable!')
+            candidates = [role for role in ctx.guild.roles if self.normalize(role.name) == norm_name]
+
+            if not candidates:
+                role = await ctx.guild.create_role(name=name, reason='Giveable role created by {}'.format(ctx.author))
+            elif len(candidates) == 1:
+                role = candidates[0]
+            else:
+                raise BadArgument('{} roles with that name exist!'.format(len(candidates)))
+            settings.giveable_roles.append(GiveableRole.from_role(role))
+        await ctx.send(
+            'Role "{0}" added! Use `{1}{2} {0}` to get it!'.format(role.name, ctx.prefix, ctx.command.parent))
+
+    add.example_usage = """
 	`{prefix}giveme add Java` - creates or finds a role named "Java" and makes it giveable
 	`{prefix}giveme Java` - gives you the Java role that was just found or created
 	"""
-	
-	@giveme.command()
-	@bot_has_permissions(manage_roles=True)
-	@has_permissions(manage_guild=True)
-	async def create(self, ctx, *, name):
-		"""Create a giveable role. Name must not contain commas.
-		Similar to add, but will always create a new role."""
-		if ',' in name:
-			raise BadArgument('giveable role names must not contain commas!')
-		norm_name = self.normalize(name)
-		with db.Session() as session:
-			settings = session.query(GuildSettings).filter_by(id=ctx.guild.id).one_or_none()
-			if settings is None:
-				settings = GuildSettings(id=ctx.guild.id)
-				session.add(settings)
-			if norm_name in (giveable.norm_name for giveable in settings.giveable_roles):
-				raise BadArgument('that role already exists and is giveable!')
-			
-			role = await ctx.guild.create_role(name=name, reason='Giveable role created by {}'.format(ctx.author))
-			settings.giveable_roles.append(GiveableRole.from_role(role))
-		await ctx.send('Role "{0}" created! Use `{1}{2} {0}` to get it!'.format(role.name, ctx.prefix, ctx.command.parent))
-	
-	create.example_usage = """
+
+    @giveme.command()
+    @bot_has_permissions(manage_roles=True)
+    @has_permissions(manage_guild=True)
+    async def create(self, ctx, *, name):
+        """Create a giveable role. Name must not contain commas.
+        Similar to add, but will always create a new role."""
+        if ',' in name:
+            raise BadArgument('giveable role names must not contain commas!')
+        norm_name = self.normalize(name)
+        with db.Session() as session:
+            settings = session.query(GuildSettings).filter_by(id=ctx.guild.id).one_or_none()
+            if settings is None:
+                settings = GuildSettings(id=ctx.guild.id)
+                session.add(settings)
+            if norm_name in (giveable.norm_name for giveable in settings.giveable_roles):
+                raise BadArgument('that role already exists and is giveable!')
+
+            role = await ctx.guild.create_role(name=name, reason='Giveable role created by {}'.format(ctx.author))
+            settings.giveable_roles.append(GiveableRole.from_role(role))
+        await ctx.send(
+            'Role "{0}" created! Use `{1}{2} {0}` to get it!'.format(role.name, ctx.prefix, ctx.command.parent))
+
+    create.example_usage = """
 	`{prefix}giveme create Python` - creates a role named "Python" and makes it giveable
 	`{prefix}giveme Python` - gives you the Python role that was just created
 	"""
-	
-	@giveme.command()
-	@bot_has_permissions(manage_roles=True)
-	async def remove(self, ctx, *, roles):
-		"""Removes multiple giveable roles from you. Names must be separated by commas."""
-		norm_names = [self.normalize(name) for name in roles.split(',')]
-		with db.Session() as session:
-			query = session.query(GiveableRole.id).filter(GiveableRole.guild_id == ctx.guild.id, GiveableRole.norm_name.in_(norm_names))
-			removable_ids = [tup[0] for tup in query.all()]
-			valid = set(role for role in ctx.guild.roles if role.id in removable_ids)
-		
-		removed = valid & set(ctx.author.roles)
-		dont_have = valid - removed
-		await ctx.author.remove_roles(*removed)
-		
-		e = discord.Embed(color=discord.Color.blue())
-		if removed:
-			removed_names = sorted((role.name for role in removed), key=str.casefold)
-			e.add_field(name='Removed {} role(s)!'.format(len(removed)), value='\n'.join(removed_names), inline=False)
-		if dont_have:
-			dont_have_names = sorted((role.name for role in dont_have), key=str.casefold)
-			e.add_field(name='You didn\'t have {} role(s)!'.format(len(dont_have)), value='\n'.join(dont_have_names), inline=False)
-		extra = len(norm_names) - len(valid)
-		if extra > 0:
-			e.add_field(name='{} role(s) could not be found!'.format(extra), value='Use `{0.prefix}{0.invoked_with} list` to find valid giveable roles!'.format(ctx), inline=False)
-		await ctx.send(embed=e)
-	
-	remove.example_usage = """
+
+    @giveme.command()
+    @bot_has_permissions(manage_roles=True)
+    async def remove(self, ctx, *, roles):
+        """Removes multiple giveable roles from you. Names must be separated by commas."""
+        norm_names = [self.normalize(name) for name in roles.split(',')]
+        with db.Session() as session:
+            query = session.query(GiveableRole.id).filter(GiveableRole.guild_id == ctx.guild.id,
+                                                          GiveableRole.norm_name.in_(norm_names))
+            removable_ids = [tup[0] for tup in query.all()]
+            valid = set(role for role in ctx.guild.roles if role.id in removable_ids)
+
+        removed = valid & set(ctx.author.roles)
+        dont_have = valid - removed
+        await ctx.author.remove_roles(*removed)
+
+        e = discord.Embed(color=discord.Color.blue())
+        if removed:
+            removed_names = sorted((role.name for role in removed), key=str.casefold)
+            e.add_field(name='Removed {} role(s)!'.format(len(removed)), value='\n'.join(removed_names), inline=False)
+        if dont_have:
+            dont_have_names = sorted((role.name for role in dont_have), key=str.casefold)
+            e.add_field(name='You didn\'t have {} role(s)!'.format(len(dont_have)), value='\n'.join(dont_have_names),
+                        inline=False)
+        extra = len(norm_names) - len(valid)
+        if extra > 0:
+            e.add_field(name='{} role(s) could not be found!'.format(extra),
+                        value='Use `{0.prefix}{0.invoked_with} list` to find valid giveable roles!'.format(ctx),
+                        inline=False)
+        await ctx.send(embed=e)
+
+    remove.example_usage = """
 	`{prefix}giveme remove Java` - removes the role called "Java" from you (if it can be given with `{prefix}giveme`)
 	`{prefix}giveme remove Java, Python` - removes the roles called "Java" and "Python" from you
 	"""
-	
-	@giveme.command()
-	@bot_has_permissions(manage_roles=True)
-	@has_permissions(manage_guild=True)
-	async def delete(self, ctx, *, name):
-		"""Deletes and removes a giveable role."""
-		if ',' in name:
-			raise BadArgument('this command only works with single roles!')
-		norm_name = self.normalize(name)
-		valid_ids = set(role.id for role in ctx.guild.roles)
-		with db.Session() as session:
-			try:
-				role = session.query(GiveableRole).filter(GiveableRole.guild_id == ctx.guild.id, GiveableRole.norm_name == norm_name, GiveableRole.id.in_(valid_ids)).one()
-			except MultipleResultsFound:
-				raise BadArgument('multiple giveable roles with that name exist!')
-			except NoResultFound:
-				raise BadArgument('that role does not exist or is not giveable!')
-			else:
-				session.delete(role)
-		role = discord.utils.get(ctx.guild.roles, id=role.id) # Not null because we already checked for id in valid_ids
-		await role.delete(reason='Giveable role deleted by {}'.format(ctx.author))
-		await ctx.send('Role "{0}" deleted!'.format(role))
-	
-	delete.example_usage = """
+
+    @giveme.command()
+    @bot_has_permissions(manage_roles=True)
+    @has_permissions(manage_guild=True)
+    async def delete(self, ctx, *, name):
+        """Deletes and removes a giveable role."""
+        if ',' in name:
+            raise BadArgument('this command only works with single roles!')
+        norm_name = self.normalize(name)
+        valid_ids = set(role.id for role in ctx.guild.roles)
+        with db.Session() as session:
+            try:
+                role = session.query(GiveableRole).filter(GiveableRole.guild_id == ctx.guild.id,
+                                                          GiveableRole.norm_name == norm_name,
+                                                          GiveableRole.id.in_(valid_ids)).one()
+            except MultipleResultsFound:
+                raise BadArgument('multiple giveable roles with that name exist!')
+            except NoResultFound:
+                raise BadArgument('that role does not exist or is not giveable!')
+            else:
+                session.delete(role)
+        role = discord.utils.get(ctx.guild.roles, id=role.id)  # Not null because we already checked for id in valid_ids
+        await role.delete(reason='Giveable role deleted by {}'.format(ctx.author))
+        await ctx.send('Role "{0}" deleted!'.format(role))
+
+    delete.example_usage = """
 	`{prefix}giveme delete Java` - deletes the role called "Java" if it's giveable (automatically removes it from all members)
 	"""
 
-	@cooldown(1, 10, BucketType.channel)
-	@giveme.command(name='list')
-	@bot_has_permissions(manage_roles=True)
-	async def list_roles(self, ctx):
-		"""Lists all giveable roles for this server."""
-		with db.Session() as session:
-			names = [tup[0] for tup in session.query(GiveableRole.name).filter_by(guild_id=ctx.guild.id)]
-		e = discord.Embed(title='Roles available to self-assign', color=discord.Color.blue())
-		e.description = '\n'.join(sorted(names, key=str.casefold))
-		await ctx.send(embed=e)
-	
-	list_roles.example_usage = """
+    @cooldown(1, 10, BucketType.channel)
+    @giveme.command(name='list')
+    @bot_has_permissions(manage_roles=True)
+    async def list_roles(self, ctx):
+        """Lists all giveable roles for this server."""
+        with db.Session() as session:
+            names = [tup[0] for tup in session.query(GiveableRole.name).filter_by(guild_id=ctx.guild.id)]
+        e = discord.Embed(title='Roles available to self-assign', color=discord.Color.blue())
+        e.description = '\n'.join(sorted(names, key=str.casefold))
+        await ctx.send(embed=e)
+
+    list_roles.example_usage = """
 	`{prefix}giveme list` - lists all giveable roles
 	"""
-	
-	@staticmethod
-	def normalize(name):
-		return name.strip().casefold()
 
-	@giveme.command()
-	@bot_has_permissions(manage_roles=True)
-	@has_permissions(manage_guild=True)
-	async def removefromlist(self, ctx, *, name):
-		"""Deletes and removes a giveable role."""
-		#Honestly this is the giveme delete command but modified to only delete from the DB
-		if ',' in name:
-			raise BadArgument('this command only works with single roles!')
-		norm_name = self.normalize(name)
-		valid_ids = set(role.id for role in ctx.guild.roles)
-		with db.Session() as session:
-			try:
-				role = session.query(GiveableRole).filter(GiveableRole.guild_id == ctx.guild.id, GiveableRole.norm_name == norm_name, GiveableRole.id.in_(valid_ids)).one()
-			except MultipleResultsFound:
-				raise BadArgument('multiple giveable roles with that name exist!')
-			except NoResultFound:
-				raise BadArgument('that role does not exist or is not giveable!')
-			else:
-				session.delete(role)
-		await ctx.send('Role "{0}" deleted from list!'.format(name))
+    @staticmethod
+    def normalize(name):
+        return name.strip().casefold()
 
-	delete.example_usage = """
+    @giveme.command()
+    @bot_has_permissions(manage_roles=True)
+    @has_permissions(manage_guild=True)
+    async def removefromlist(self, ctx, *, name):
+        """Deletes and removes a giveable role."""
+        # Honestly this is the giveme delete command but modified to only delete from the DB
+        if ',' in name:
+            raise BadArgument('this command only works with single roles!')
+        norm_name = self.normalize(name)
+        valid_ids = set(role.id for role in ctx.guild.roles)
+        with db.Session() as session:
+            try:
+                role = session.query(GiveableRole).filter(GiveableRole.guild_id == ctx.guild.id,
+                                                          GiveableRole.norm_name == norm_name,
+                                                          GiveableRole.id.in_(valid_ids)).one()
+            except MultipleResultsFound:
+                raise BadArgument('multiple giveable roles with that name exist!')
+            except NoResultFound:
+                raise BadArgument('that role does not exist or is not giveable!')
+            else:
+                session.delete(role)
+        await ctx.send('Role "{0}" deleted from list!'.format(name))
+
+    delete.example_usage = """
 	`{prefix}giveme removefromlist Java` - removes the role "Java" from the list of giveable roles but does not remove it from the server or members who have it 
 	"""
 
-	@command()
-	@bot_has_permissions(manage_roles=True)
-	@has_permissions(manage_roles=True)
-	async def give(self, ctx, member : discord.Member, *, role : discord.Role):
-		"""Gives a member a role. Not restricted to giveable roles."""
-		if role > ctx.author.top_role:
-			raise BadArgument('Cannot give roles higher than your top role!')
-		await member.add_roles(role)
-		await ctx.send('Successfully gave {} {}!'.format(member, role))
-	
-	give.example_usage = """
+    @command()
+    @bot_has_permissions(manage_roles=True)
+    @has_permissions(manage_roles=True)
+    async def give(self, ctx, member: discord.Member, *, role: discord.Role):
+        """Gives a member a role. Not restricted to giveable roles."""
+        if role > ctx.author.top_role:
+            raise BadArgument('Cannot give roles higher than your top role!')
+        await member.add_roles(role)
+        await ctx.send('Successfully gave {} {}!'.format(member, role))
+
+    give.example_usage = """
 	`{prefix}give cooldude#1234 Java` - gives cooldude any role, giveable or not, named Java
 	"""
-	
-	@command()
-	@bot_has_permissions(manage_roles=True)
-	@has_permissions(manage_roles=True)
-	async def take(self, ctx, member : discord.Member, *, role : discord.Role):
-		"""Takes a role from a member. Not restricted to giveable roles."""
-		if role > ctx.author.top_role:
-			raise BadArgument('Cannot take roles higher than your top role!')
-		await member.remove_roles(role)
-		await ctx.send('Successfully removed "{}" from {}!'.format(role, member))
-	
-	take.example_usage = """
+
+    @command()
+    @bot_has_permissions(manage_roles=True)
+    @has_permissions(manage_roles=True)
+    async def take(self, ctx, member: discord.Member, *, role: discord.Role):
+        """Takes a role from a member. Not restricted to giveable roles."""
+        if role > ctx.author.top_role:
+            raise BadArgument('Cannot take roles higher than your top role!')
+        await member.remove_roles(role)
+        await ctx.send('Successfully removed "{}" from {}!'.format(role, member))
+
+    take.example_usage = """
 	`{prefix}take cooldude#1234 Java` - takes any role named Java, giveable or not, from cooldude
 	"""
 
+
 class GuildSettings(db.DatabaseObject):
-	__tablename__ = 'guilds'
-	id = db.Column(db.Integer, primary_key=True)
-	giveable_roles = db.relationship('GiveableRole', back_populates='guild_settings')
+    __tablename__ = 'guilds'
+    id = db.Column(db.Integer, primary_key=True)
+    giveable_roles = db.relationship('GiveableRole', back_populates='guild_settings')
+
 
 class GiveableRole(db.DatabaseObject):
-	__tablename__ = 'giveable_roles'
-	id = db.Column(db.Integer, primary_key=True)
-	name = db.Column(db.String(100), nullable=False)
-	norm_name = db.Column(db.String(100), nullable=False)
-	guild_id = db.Column(db.Integer, db.ForeignKey('guilds.id'))
-	guild_settings = db.relationship('GuildSettings', back_populates='giveable_roles')
-	
-	@classmethod
-	def from_role(cls, role):
-		"""Creates a GiveableRole record from a discord.Role."""
-		return cls(id=role.id, name=role.name, norm_name=Roles.normalize(role.name))
+    __tablename__ = 'giveable_roles'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), nullable=False)
+    norm_name = db.Column(db.String(100), nullable=False)
+    guild_id = db.Column(db.Integer, db.ForeignKey('guilds.id'))
+    guild_settings = db.relationship('GuildSettings', back_populates='giveable_roles')
+
+    @classmethod
+    def from_role(cls, role):
+        """Creates a GiveableRole record from a discord.Role."""
+        return cls(id=role.id, name=role.name, norm_name=Roles.normalize(role.name))
+
 
 class MissingMember(db.DatabaseObject):
-	__tablename__ = 'missing_members'
-	guild_id = db.Column(db.Integer, primary_key=True)
-	member_id = db.Column(db.Integer, primary_key=True)
-	missing_roles = db.relationship('MissingRole', back_populates='member', cascade='all, delete, delete-orphan')
+    __tablename__ = 'missing_members'
+    guild_id = db.Column(db.Integer, primary_key=True)
+    member_id = db.Column(db.Integer, primary_key=True)
+    missing_roles = db.relationship('MissingRole', back_populates='member', cascade='all, delete, delete-orphan')
+
 
 class MissingRole(db.DatabaseObject):
-	__tablename__ = 'missing_roles'
-	__table_args__ = (db.ForeignKeyConstraint(['guild_id', 'member_id'], ['missing_members.guild_id', 'missing_members.member_id']),)
-	role_id = db.Column(db.Integer, primary_key=True)
-	guild_id = db.Column(db.Integer) # Guild ID doesn't have to be primary because role IDs are unique across guilds
-	member_id = db.Column(db.Integer, primary_key=True)
-	role_name = db.Column(db.String(100), nullable=False)
-	member = db.relationship('MissingMember', back_populates='missing_roles')
+    __tablename__ = 'missing_roles'
+    __table_args__ = (
+    db.ForeignKeyConstraint(['guild_id', 'member_id'], ['missing_members.guild_id', 'missing_members.member_id']),)
+    role_id = db.Column(db.Integer, primary_key=True)
+    guild_id = db.Column(db.Integer)  # Guild ID doesn't have to be primary because role IDs are unique across guilds
+    member_id = db.Column(db.Integer, primary_key=True)
+    role_name = db.Column(db.String(100), nullable=False)
+    member = db.relationship('MissingMember', back_populates='missing_roles')
+
 
 def setup(bot):
-	bot.add_cog(Roles(bot))
+    bot.add_cog(Roles(bot))

--- a/dozer/cogs/roles.py
+++ b/dozer/cogs/roles.py
@@ -93,9 +93,9 @@ class Roles(Cog):
         await ctx.send(embed=e)
 
     giveme.example_usage = """
-	`{prefix}giveme Java` - gives you the role called Java, if it exists
-	`{prefix}giveme Java, Python` - gives you the roles called Java and Python, if they exist
-	"""
+    `{prefix}giveme Java` - gives you the role called Java, if it exists
+    `{prefix}giveme Java, Python` - gives you the roles called Java and Python, if they exist
+    """
 
     @giveme.command()
     @bot_has_permissions(manage_roles=True)
@@ -126,9 +126,9 @@ class Roles(Cog):
             'Role "{0}" added! Use `{1}{2} {0}` to get it!'.format(role.name, ctx.prefix, ctx.command.parent))
 
     add.example_usage = """
-	`{prefix}giveme add Java` - creates or finds a role named "Java" and makes it giveable
-	`{prefix}giveme Java` - gives you the Java role that was just found or created
-	"""
+    `{prefix}giveme add Java` - creates or finds a role named "Java" and makes it giveable
+    `{prefix}giveme Java` - gives you the Java role that was just found or created
+    """
 
     @giveme.command()
     @bot_has_permissions(manage_roles=True)
@@ -153,9 +153,9 @@ class Roles(Cog):
             'Role "{0}" created! Use `{1}{2} {0}` to get it!'.format(role.name, ctx.prefix, ctx.command.parent))
 
     create.example_usage = """
-	`{prefix}giveme create Python` - creates a role named "Python" and makes it giveable
-	`{prefix}giveme Python` - gives you the Python role that was just created
-	"""
+    `{prefix}giveme create Python` - creates a role named "Python" and makes it giveable
+    `{prefix}giveme Python` - gives you the Python role that was just created
+    """
 
     @giveme.command()
     @bot_has_permissions(manage_roles=True)
@@ -188,9 +188,9 @@ class Roles(Cog):
         await ctx.send(embed=e)
 
     remove.example_usage = """
-	`{prefix}giveme remove Java` - removes the role called "Java" from you (if it can be given with `{prefix}giveme`)
-	`{prefix}giveme remove Java, Python` - removes the roles called "Java" and "Python" from you
-	"""
+    `{prefix}giveme remove Java` - removes the role called "Java" from you (if it can be given with `{prefix}giveme`)
+    `{prefix}giveme remove Java, Python` - removes the roles called "Java" and "Python" from you
+    """
 
     @giveme.command()
     @bot_has_permissions(manage_roles=True)
@@ -217,8 +217,8 @@ class Roles(Cog):
         await ctx.send('Role "{0}" deleted!'.format(role))
 
     delete.example_usage = """
-	`{prefix}giveme delete Java` - deletes the role called "Java" if it's giveable (automatically removes it from all members)
-	"""
+    `{prefix}giveme delete Java` - deletes the role called "Java" if it's giveable (automatically removes it from all members)
+    """
 
     @cooldown(1, 10, BucketType.channel)
     @giveme.command(name='list')
@@ -232,8 +232,8 @@ class Roles(Cog):
         await ctx.send(embed=e)
 
     list_roles.example_usage = """
-	`{prefix}giveme list` - lists all giveable roles
-	"""
+    `{prefix}giveme list` - lists all giveable roles
+    """
 
     @staticmethod
     def normalize(name):
@@ -263,8 +263,8 @@ class Roles(Cog):
         await ctx.send('Role "{0}" deleted from list!'.format(name))
 
     delete.example_usage = """
-	`{prefix}giveme removefromlist Java` - removes the role "Java" from the list of giveable roles but does not remove it from the server or members who have it 
-	"""
+    `{prefix}giveme removefromlist Java` - removes the role "Java" from the list of giveable roles but does not remove it from the server or members who have it 
+    """
 
     @command()
     @bot_has_permissions(manage_roles=True)
@@ -277,8 +277,8 @@ class Roles(Cog):
         await ctx.send('Successfully gave {} {}!'.format(member, role))
 
     give.example_usage = """
-	`{prefix}give cooldude#1234 Java` - gives cooldude any role, giveable or not, named Java
-	"""
+    `{prefix}give cooldude#1234 Java` - gives cooldude any role, giveable or not, named Java
+    """
 
     @command()
     @bot_has_permissions(manage_roles=True)
@@ -291,8 +291,8 @@ class Roles(Cog):
         await ctx.send('Successfully removed "{}" from {}!'.format(role, member))
 
     take.example_usage = """
-	`{prefix}take cooldude#1234 Java` - takes any role named Java, giveable or not, from cooldude
-	"""
+    `{prefix}take cooldude#1234 Java` - takes any role named Java, giveable or not, from cooldude
+    """
 
 
 class GuildSettings(db.DatabaseObject):

--- a/dozer/cogs/tba.py
+++ b/dozer/cogs/tba.py
@@ -28,8 +28,8 @@ class TBA(Cog):
         await self.team.callback(self, ctx, team_num)
 
     tba.example_usage = """
-	`{prefix}tba 5052` - show information on team 5052, the RoboLobos
-	"""
+    `{prefix}tba 5052` - show information on team 5052, the RoboLobos
+    """
 
     @tba.command()
     @bot_has_permissions(embed_links=True)
@@ -55,8 +55,8 @@ class TBA(Cog):
             raise BadArgument("Couldn't find data for team {}".format(team_num))
 
     team.example_usage = """
-	`{prefix}tba team 4131` - show information on team 4131, the Iron Patriots
-	"""
+    `{prefix}tba team 4131` - show information on team 4131, the Iron Patriots
+    """
 
     @tba.command()
     async def raw(self, ctx, team_num: int):
@@ -79,8 +79,8 @@ class TBA(Cog):
             raise BadArgument('Team {} does not exist.'.format(team_num))
 
     raw.example_usage = """
-	`{prefix}tba raw 4150` - show raw information on team 4150, FRobotics
-	"""
+    `{prefix}tba raw 4150` - show raw information on team 4150, FRobotics
+    """
 
     @command()
     async def timezone(self, ctx, team_num: int):
@@ -131,8 +131,8 @@ class TBA(Cog):
             raise BadArgument('Team {} does not exist.'.format(team_num))
 
     timezone.example_usage = """
-	`{prefix}timezone 3572` - show the local time of team 3572, Wavelength
-	"""
+    `{prefix}timezone 3572` - show the local time of team 3572, Wavelength
+    """
 
 
 def setup(bot):

--- a/dozer/cogs/tba.py
+++ b/dozer/cogs/tba.py
@@ -1,125 +1,139 @@
-import tbapi
+import datetime
+from datetime import timedelta
+
 import discord
 import googlemaps
-import datetime
-from ._utils import *
-from discord.ext import commands
-from discord.ext.commands import BadArgument, Group, bot_has_permissions, has_permissions
+import tbapi
+from discord.ext.commands import BadArgument, bot_has_permissions
 from geopy.geocoders import Nominatim
-from datetime import timedelta
+
+from ._utils import *
 
 blurple = discord.Color.blurple()
 
 
 class TBA(Cog):
-	def __init__(self, bot):
-		super().__init__(bot)
-		tba_config = bot.config['tba']
-		self.gmaps_key = bot.config['gmaps_key']
-		self.parser = tbapi.TBAParser(tba_config['key'], cache=False)
-	
-	@group(invoke_without_command=True)
-	async def tba(self, ctx, team_num: int):
-		"""
-		Get FRC-related information from The Blue Alliance.
-		If no subcommand is specified, the `team` subcommand is inferred, and the argument is taken as a team number.
-		"""
-		await self.team.callback(self, ctx, team_num)
-	
-	tba.example_usage = """
+    def __init__(self, bot):
+        super().__init__(bot)
+        tba_config = bot.config['tba']
+        self.gmaps_key = bot.config['gmaps_key']
+        self.parser = tbapi.TBAParser(tba_config['key'], cache=False)
+
+    @group(invoke_without_command=True)
+    async def tba(self, ctx, team_num: int):
+        """
+        Get FRC-related information from The Blue Alliance.
+        If no subcommand is specified, the `team` subcommand is inferred, and the argument is taken as a team number.
+        """
+        await self.team.callback(self, ctx, team_num)
+
+    tba.example_usage = """
 	`{prefix}tba 5052` - show information on team 5052, the RoboLobos
 	"""
-	
-	@tba.command()
-	@bot_has_permissions(embed_links=True)
-	async def team(self, ctx, team_num: int):
-		"""Get information on an FRC team by number."""
-		team_data = self.parser.get_team(team_num)
-		try:
-			getattr(team_data, "Errors")
-		except tbapi.InvalidKeyError:
-			e = discord.Embed(color=blurple)
-			e.set_author(name='FIRST® Robotics Competition Team {}'.format(team_num), url='https://www.thebluealliance.com/team/{}'.format(team_num), icon_url='https://frcavatars.herokuapp.com/get_image?team={}'.format(team_num))
-			e.add_field(name='Name', value=team_data.nickname)
-			e.add_field(name='Rookie Year', value=team_data.rookie_year)
-			e.add_field(name='Location', value='{0.city}, {0.state_prov} {0.postal_code}, {0.country}'.format(team_data))
-			e.add_field(name='Website', value=team_data.website)
-			e.add_field(name='TBA Link', value='https://www.thebluealliance.com/team/{}'.format(team_num))
-			e.set_footer(text='Triggered by ' + ctx.author.display_name)
-			await ctx.send(embed=e)
-		else:
-			raise BadArgument("Couldn't find data for team {}".format(team_num))
 
-	team.example_usage = """
+    @tba.command()
+    @bot_has_permissions(embed_links=True)
+    async def team(self, ctx, team_num: int):
+        """Get information on an FRC team by number."""
+        team_data = self.parser.get_team(team_num)
+        try:
+            getattr(team_data, "Errors")
+        except tbapi.InvalidKeyError:
+            e = discord.Embed(color=blurple)
+            e.set_author(name='FIRST® Robotics Competition Team {}'.format(team_num),
+                         url='https://www.thebluealliance.com/team/{}'.format(team_num),
+                         icon_url='https://frcavatars.herokuapp.com/get_image?team={}'.format(team_num))
+            e.add_field(name='Name', value=team_data.nickname)
+            e.add_field(name='Rookie Year', value=team_data.rookie_year)
+            e.add_field(name='Location',
+                        value='{0.city}, {0.state_prov} {0.postal_code}, {0.country}'.format(team_data))
+            e.add_field(name='Website', value=team_data.website)
+            e.add_field(name='TBA Link', value='https://www.thebluealliance.com/team/{}'.format(team_num))
+            e.set_footer(text='Triggered by ' + ctx.author.display_name)
+            await ctx.send(embed=e)
+        else:
+            raise BadArgument("Couldn't find data for team {}".format(team_num))
+
+    team.example_usage = """
 	`{prefix}tba team 4131` - show information on team 4131, the Iron Patriots
 	"""
 
-	@tba.command()
-	async def raw(self, ctx, team_num: int):
-		"""
-		Get raw TBA API output for a team.
-		This command is really only useful for development.
-		"""
-		team_data = self.parser.get_team(team_num)
-		try:
-			getattr(team_data, "Errors")
-		except tbapi.InvalidKeyError:
-			e = discord.Embed(color=blurple)
-			e.set_author(name='FIRST® Robotics Competition Team {}'.format(team_num), url='https://www.thebluealliance.com/team/{}'.format(team_num), icon_url='https://frcavatars.herokuapp.com/get_image?team={}'.format(team_num))
-			e.add_field(name='Raw Data', value=team_data.flatten())
-			e.set_footer(text='Triggered by ' + ctx.author.display_name)
-			await ctx.send(embed=e)
-		else:
-			raise BadArgument('Team {} does not exist.'.format(team_num))
+    @tba.command()
+    async def raw(self, ctx, team_num: int):
+        """
+        Get raw TBA API output for a team.
+        This command is really only useful for development.
+        """
+        team_data = self.parser.get_team(team_num)
+        try:
+            getattr(team_data, "Errors")
+        except tbapi.InvalidKeyError:
+            e = discord.Embed(color=blurple)
+            e.set_author(name='FIRST® Robotics Competition Team {}'.format(team_num),
+                         url='https://www.thebluealliance.com/team/{}'.format(team_num),
+                         icon_url='https://frcavatars.herokuapp.com/get_image?team={}'.format(team_num))
+            e.add_field(name='Raw Data', value=team_data.flatten())
+            e.set_footer(text='Triggered by ' + ctx.author.display_name)
+            await ctx.send(embed=e)
+        else:
+            raise BadArgument('Team {} does not exist.'.format(team_num))
 
-	raw.example_usage = """
+    raw.example_usage = """
 	`{prefix}tba raw 4150` - show raw information on team 4150, FRobotics
 	"""
 
-	@command()
-	async def timezone(self, ctx, team_num: int):
-		"""
-		Get the timezone of a team based on the team number.
-		"""
+    @command()
+    async def timezone(self, ctx, team_num: int):
+        """
+        Get the timezone of a team based on the team number.
+        """
 
-		team_data = self.parser.get_team(team_num)
-		try:
-			getattr(team_data, "Errors")
-		except tbapi.InvalidKeyError:
-			location = '{0.city}, {0.state_prov} {0.postal_code}, {0.country}'.format(team_data)
-			gmaps = googlemaps.Client(key=self.gmaps_key)
-			geolocator = Nominatim()
-			geolocation = geolocator.geocode(location)
-			timezone = gmaps.timezone(location="{}, {}".format(geolocation.latitude, geolocation.longitude), language="json")
-			utc_offset = int(timezone["rawOffset"])/3600
-			if timezone["dstOffset"] == 3600:
-				utc_offset += 1
-			utc_timedelta = timedelta(hours = utc_offset)
-			currentUTCTime = datetime.datetime.utcnow()
-			currentTime = currentUTCTime+utc_timedelta
-			current_hour = currentTime.hour
-			current_hour_original = current_hour
-			dayTime = "AM"
-			if current_hour > 12:
-				current_hour -= 12
-				dayTime = "PM"
-			elif current_hour == 12:
-				dayTime = "PM"
-			elif current_hour == 0:
-				current_hour = 12
-				dayTime = "AM"
-			current_minute = currentTime.minute
-			if current_minute < 10:
-				current_minute = "0{}".format(current_minute)
-			current_second = currentTime.second
-			if current_second < 10:
-				current_second = "0{}".format(current_second)
-			await ctx.send("Timezone: {0} UTC{1:+g} \nCurrent Time: {2}:{3}:{4} {5} ({6}:{3}:{4})".format(timezone["timeZoneName"], utc_offset, current_hour, current_minute, current_second, dayTime, current_hour_original))
-		else:
-			raise BadArgument('Team {} does not exist.'.format(team_num))
-					
-	timezone.example_usage = """
+        team_data = self.parser.get_team(team_num)
+        try:
+            getattr(team_data, "Errors")
+        except tbapi.InvalidKeyError:
+            location = '{0.city}, {0.state_prov} {0.postal_code}, {0.country}'.format(team_data)
+            gmaps = googlemaps.Client(key=self.gmaps_key)
+            geolocator = Nominatim()
+            geolocation = geolocator.geocode(location)
+            timezone = gmaps.timezone(location="{}, {}".format(geolocation.latitude, geolocation.longitude),
+                                      language="json")
+            utc_offset = int(timezone["rawOffset"]) / 3600
+            if timezone["dstOffset"] == 3600:
+                utc_offset += 1
+            utc_timedelta = timedelta(hours=utc_offset)
+            currentUTCTime = datetime.datetime.utcnow()
+            currentTime = currentUTCTime + utc_timedelta
+            current_hour = currentTime.hour
+            current_hour_original = current_hour
+            dayTime = "AM"
+            if current_hour > 12:
+                current_hour -= 12
+                dayTime = "PM"
+            elif current_hour == 12:
+                dayTime = "PM"
+            elif current_hour == 0:
+                current_hour = 12
+                dayTime = "AM"
+            current_minute = currentTime.minute
+            if current_minute < 10:
+                current_minute = "0{}".format(current_minute)
+            current_second = currentTime.second
+            if current_second < 10:
+                current_second = "0{}".format(current_second)
+            await ctx.send(
+                "Timezone: {0} UTC{1:+g} \nCurrent Time: {2}:{3}:{4} {5} ({6}:{3}:{4})".format(timezone["timeZoneName"],
+                                                                                               utc_offset, current_hour,
+                                                                                               current_minute,
+                                                                                               current_second, dayTime,
+                                                                                               current_hour_original))
+        else:
+            raise BadArgument('Team {} does not exist.'.format(team_num))
+
+    timezone.example_usage = """
 	`{prefix}timezone 3572` - show the local time of team 3572, Wavelength
 	"""
+
+
 def setup(bot):
-	bot.add_cog(TBA(bot))
+    bot.add_cog(TBA(bot))

--- a/dozer/cogs/tba.py
+++ b/dozer/cogs/tba.py
@@ -122,11 +122,8 @@ class TBA(Cog):
             if current_second < 10:
                 current_second = "0{}".format(current_second)
             await ctx.send(
-                "Timezone: {0} UTC{1:+g} \nCurrent Time: {2}:{3}:{4} {5} ({6}:{3}:{4})".format(timezone["timeZoneName"],
-                                                                                               utc_offset, current_hour,
-                                                                                               current_minute,
-                                                                                               current_second, dayTime,
-                                                                                               current_hour_original))
+                "Timezone: {0} UTC{1:+g} \nCurrent Time: {2}:{3}:{4} {5} ({6}:{3}:{4})".format(
+                timezone["timeZoneName"], utc_offset, current_hour, current_minute, current_second, dayTime, current_hour_original))
         else:
             raise BadArgument('Team {} does not exist.'.format(team_num))
 

--- a/dozer/cogs/teams.py
+++ b/dozer/cogs/teams.py
@@ -21,8 +21,8 @@ class Teams(Cog):
                 raise BadArgument("You are already associated with that team!")
 
     setteam.example_usage = """
-	`{prefix}setteam type team_number` - Creates an association in the database with a specified team
-	"""
+    `{prefix}setteam type team_number` - Creates an association in the database with a specified team
+    """
 
     @command()
     async def removeteam(self, ctx, team_type, team_number):
@@ -38,8 +38,8 @@ class Teams(Cog):
                 await ctx.send("Couldn't find any associations with that team!")
 
     removeteam.example_usage = """
-	`{prefix}removeteam type team_number` - Removes your associations with a specified team 
-	"""
+    `{prefix}removeteam type team_number` - Removes your associations with a specified team 
+    """
 
     @command()
     async def teamsfor(self, ctx, user: discord.Member = None):
@@ -60,8 +60,8 @@ class Teams(Cog):
                 await ctx.send(embed=e)
 
     teamsfor.example_usage = """
-	`{prefix}teamsfor member` - Returns all team associations with the mentioned user. Assumes caller if blank.
-	"""
+    `{prefix}teamsfor member` - Returns all team associations with the mentioned user. Assumes caller if blank.
+    """
 
     @command()
     async def onteam(self, ctx, team_type, team_number):
@@ -82,8 +82,8 @@ class Teams(Cog):
                 await ctx.send(embed=e)
 
     onteam.example_usage = """
-	`{prefix}onteam type team_number` - Returns a list of users associated with a given team type and number
-	"""
+    `{prefix}onteam type team_number` - Returns a list of users associated with a given team type and number
+    """
 
     async def on_member_join(self, member):
         if member.guild.me.guild_permissions.manage_nicknames:

--- a/dozer/cogs/teams.py
+++ b/dozer/cogs/teams.py
@@ -1,99 +1,106 @@
-
-from .. import db
-from ._utils import *
 import discord
 from discord.ext.commands import BadArgument
 
+from ._utils import *
+from .. import db
+
 
 class Teams(Cog):
-	@command()
-	async def setteam(self, ctx, team_type, team_number: int):
-		"""Sets an association with your team in the database."""
-		team_type = team_type.casefold()
-		with db.Session() as session:
-			dbcheck = session.query(TeamNumbers).filter_by(user_id=ctx.author.id, team_number=team_number, team_type=team_type).one_or_none()
-			if dbcheck is None:
-				dbtransaction = TeamNumbers(user_id=ctx.author.id, team_number=team_number, team_type=team_type)
-				session.add(dbtransaction)
-				await ctx.send("Team number set!")
-			else:
-				raise BadArgument("You are already associated with that team!")
-	setteam.example_usage = """
+    @command()
+    async def setteam(self, ctx, team_type, team_number: int):
+        """Sets an association with your team in the database."""
+        team_type = team_type.casefold()
+        with db.Session() as session:
+            dbcheck = session.query(TeamNumbers).filter_by(user_id=ctx.author.id, team_number=team_number,
+                                                           team_type=team_type).one_or_none()
+            if dbcheck is None:
+                dbtransaction = TeamNumbers(user_id=ctx.author.id, team_number=team_number, team_type=team_type)
+                session.add(dbtransaction)
+                await ctx.send("Team number set!")
+            else:
+                raise BadArgument("You are already associated with that team!")
+
+    setteam.example_usage = """
 	`{prefix}setteam type team_number` - Creates an association in the database with a specified team
 	"""
 
-	@command()
-	async def removeteam(self, ctx, team_type, team_number):
-		"""Removes an association with a team in the database."""
-		team_type = team_type.casefold()
-		with db.Session() as session:
-			results = session.query(TeamNumbers).filter_by(user_id=ctx.author.id, team_type=team_type, team_number=team_number).one_or_none()
-			if results is not None:
-				session.delete(results)
-				await ctx.send("Removed association with {} team {}".format(team_type, team_number))
-			if results is None:
-				await ctx.send("Couldn't find any associations with that team!")
-	removeteam.example_usage = """
+    @command()
+    async def removeteam(self, ctx, team_type, team_number):
+        """Removes an association with a team in the database."""
+        team_type = team_type.casefold()
+        with db.Session() as session:
+            results = session.query(TeamNumbers).filter_by(user_id=ctx.author.id, team_type=team_type,
+                                                           team_number=team_number).one_or_none()
+            if results is not None:
+                session.delete(results)
+                await ctx.send("Removed association with {} team {}".format(team_type, team_number))
+            if results is None:
+                await ctx.send("Couldn't find any associations with that team!")
+
+    removeteam.example_usage = """
 	`{prefix}removeteam type team_number` - Removes your associations with a specified team 
 	"""
 
-	@command()
-	async def teamsfor(self, ctx, user: discord.Member=None):
-		"""Allows you to see the teams for the mentioned user. If no user is mentioned, your teams are displayed."""
-		if user is None:
-			user = ctx.author
-		with db.Session() as session:
-			teams = session.query(TeamNumbers).filter_by(user_id=user.id).order_by("team_type desc", "team_number asc").all()
-			if len(teams) is 0:
-				raise BadArgument("Couldn't find any team associations for that user!")
-			else:
-				e = discord.Embed(type='rich')
-				e.title = 'Teams for {}'.format(user.display_name)
-				e.description = "Teams: \n"
-				for i in teams:
-					e.description = "{} {} Team {} \n".format(e.description, i.team_type.upper(), i.team_number)
-				await ctx.send(embed=e)
-	teamsfor.example_usage = """
+    @command()
+    async def teamsfor(self, ctx, user: discord.Member = None):
+        """Allows you to see the teams for the mentioned user. If no user is mentioned, your teams are displayed."""
+        if user is None:
+            user = ctx.author
+        with db.Session() as session:
+            teams = session.query(TeamNumbers).filter_by(user_id=user.id).order_by("team_type desc",
+                                                                                   "team_number asc").all()
+            if len(teams) is 0:
+                raise BadArgument("Couldn't find any team associations for that user!")
+            else:
+                e = discord.Embed(type='rich')
+                e.title = 'Teams for {}'.format(user.display_name)
+                e.description = "Teams: \n"
+                for i in teams:
+                    e.description = "{} {} Team {} \n".format(e.description, i.team_type.upper(), i.team_number)
+                await ctx.send(embed=e)
+
+    teamsfor.example_usage = """
 	`{prefix}teamsfor member` - Returns all team associations with the mentioned user. Assumes caller if blank.
 	"""
 
-	@command()
-	async def onteam(self, ctx, team_type, team_number):
-		"""Allows you to see who has associated themselves with a particular team."""
-		team_type = team_type.casefold()
-		with db.Session() as session:
-			users = session.query(TeamNumbers).filter_by(team_number=team_number, team_type=team_type).all()
-			if len(users) == 0:
-				await ctx.send("Nobody on that team found!")
-			else:
-				e = discord.Embed(type='rich')
-				e.title = 'Users on team {}'.format(team_number)
-				e.description = "Users: \n"
-				for i in users:
-					user = ctx.guild.get_member(i.user_id)
-					if user is not None:
-						e.description = "{}{} {} \n".format(e.description, user.display_name, user.mention)
-				await ctx.send(embed=e)
-	onteam.example_usage = """
+    @command()
+    async def onteam(self, ctx, team_type, team_number):
+        """Allows you to see who has associated themselves with a particular team."""
+        team_type = team_type.casefold()
+        with db.Session() as session:
+            users = session.query(TeamNumbers).filter_by(team_number=team_number, team_type=team_type).all()
+            if len(users) == 0:
+                await ctx.send("Nobody on that team found!")
+            else:
+                e = discord.Embed(type='rich')
+                e.title = 'Users on team {}'.format(team_number)
+                e.description = "Users: \n"
+                for i in users:
+                    user = ctx.guild.get_member(i.user_id)
+                    if user is not None:
+                        e.description = "{}{} {} \n".format(e.description, user.display_name, user.mention)
+                await ctx.send(embed=e)
+
+    onteam.example_usage = """
 	`{prefix}onteam type team_number` - Returns a list of users associated with a given team type and number
 	"""
 
-	async def on_member_join(self, member):
-		if member.guild.me.guild_permissions.manage_nicknames:
-			with db.Session() as session:
-				query = session.query(TeamNumbers).filter_by(user_id=member.id).first()
-				if query is not None:
-					nick = "{} {}{}".format(member.display_name, query.team_type, query.team_number)
-					if len(nick) <= 32:
-						await member.edit(nick=nick)
+    async def on_member_join(self, member):
+        if member.guild.me.guild_permissions.manage_nicknames:
+            with db.Session() as session:
+                query = session.query(TeamNumbers).filter_by(user_id=member.id).first()
+                if query is not None:
+                    nick = "{} {}{}".format(member.display_name, query.team_type, query.team_number)
+                    if len(nick) <= 32:
+                        await member.edit(nick=nick)
 
 
 class TeamNumbers(db.DatabaseObject):
-	__tablename__ = 'team_numbers'
-	user_id = db.Column(db.Integer, primary_key=True)
-	team_number = db.Column(db.Integer, primary_key=True)
-	team_type = db.Column(db.String, primary_key=True)
+    __tablename__ = 'team_numbers'
+    user_id = db.Column(db.Integer, primary_key=True)
+    team_number = db.Column(db.Integer, primary_key=True)
+    team_type = db.Column(db.String, primary_key=True)
 
 
 def setup(bot):
-	bot.add_cog(Teams(bot))
+    bot.add_cog(Teams(bot))

--- a/dozer/cogs/toa.py
+++ b/dozer/cogs/toa.py
@@ -26,8 +26,8 @@ class TOA(Cog):
         await self.team.callback(self, ctx, team_num)
 
     toa.example_usage = """
-	`{prefix}toa 5667` - show information on team 5667, the Robominers
-	"""
+    `{prefix}toa 5667` - show information on team 5667, the Robominers
+    """
 
     @toa.command()
     @bot_has_permissions(embed_links=True)
@@ -70,8 +70,8 @@ class TOA(Cog):
         await ctx.send(embed=e)
 
     team.example_usage = """
-	`{prefix}toa team 12670` - show information on team 12670, Eclipse
-	"""
+    `{prefix}toa team 12670` - show information on team 12670, Eclipse
+    """
 
 
 def setup(bot):

--- a/dozer/cogs/toa.py
+++ b/dozer/cogs/toa.py
@@ -1,76 +1,78 @@
-import discord
-import datetime
-import pickle
 import gzip
-from ._utils import *
+import pickle
+
+import discord
+from discord.ext.commands import bot_has_permissions
+
 from ._toa import *
-from discord.ext import commands
-from discord.ext.commands import BadArgument, Group, bot_has_permissions, has_permissions
-from datetime import timedelta
+from ._utils import *
 
 embed_color = discord.Color(0xff9800)
-class TOA(Cog):
-	def __init__(self, bot):
-		super().__init__(bot)
-		self.parser = TOAParser(bot.config['toa']['key'], bot.http._session, app_name=bot.config['toa']['app_name'])
-		with gzip.open("ftc_teams.pickle.gz") as f:
-			self._teams = pickle.load(f)
 
-	
-	@group(invoke_without_command=True)
-	async def toa(self, ctx, team_num: int):
-		"""
-		Get FTC-related information from The Orange Alliance.
-		If no subcommand is specified, the `team` subcommand is inferred, and the argument is taken as a team number.
-		"""
-		await self.team.callback(self, ctx, team_num)
-	
-	toa.example_usage = """
+
+class TOA(Cog):
+    def __init__(self, bot):
+        super().__init__(bot)
+        self.parser = TOAParser(bot.config['toa']['key'], bot.http._session, app_name=bot.config['toa']['app_name'])
+        with gzip.open("ftc_teams.pickle.gz") as f:
+            self._teams = pickle.load(f)
+
+    @group(invoke_without_command=True)
+    async def toa(self, ctx, team_num: int):
+        """
+        Get FTC-related information from The Orange Alliance.
+        If no subcommand is specified, the `team` subcommand is inferred, and the argument is taken as a team number.
+        """
+        await self.team.callback(self, ctx, team_num)
+
+    toa.example_usage = """
 	`{prefix}toa 5667` - show information on team 5667, the Robominers
 	"""
-	
-	@toa.command()
-	@bot_has_permissions(embed_links=True)
-	async def team(self, ctx, team_num: int):
-		"""Get information on an FTC team by number."""
-		team_data = await self.parser.req("team/" + str(team_num))
-		# TOA's rookie year listing is :b:roke, so we have to fix it ourselves
-		# This is a _nasty_ hack
-		data = self._teams.get(team_num, {
-			'rookie_year': 2017,
-			'seasons': [{
-				'website': 'n/a',
-			}]
-		})
-		last_season = data['seasons'][0]
-		team_data.rookie_year = data['rookie_year']
 
-		if team_data.error:
-			if team_num not in self._teams:
-				# rip
-				await ctx.send("This team does not have any data on it yet, or it does not exist!")
-				return
-			team_data._update(last_season)
-			team_data.team_name_short = last_season['name']
+    @toa.command()
+    @bot_has_permissions(embed_links=True)
+    async def team(self, ctx, team_num: int):
+        """Get information on an FTC team by number."""
+        team_data = await self.parser.req("team/" + str(team_num))
+        # TOA's rookie year listing is :b:roke, so we have to fix it ourselves
+        # This is a _nasty_ hack
+        data = self._teams.get(team_num, {
+            'rookie_year': 2017,
+            'seasons': [{
+                'website': 'n/a',
+            }]
+        })
+        last_season = data['seasons'][0]
+        team_data.rookie_year = data['rookie_year']
 
-		# many team entries lack a valid url
-		website = (team_data.website or last_season['website']).strip()
-		if website and not (website.startswith("http://") or website.startswith("https://")):
-			website = "http://" + website
-		e = discord.Embed(color=embed_color)
-		e.set_author(name='FIRST® Tech Challenge Team {}'.format(team_num), url='https://www.theorangealliance.org/teams/{}'.format(team_num), icon_url='https://cdn.discordapp.com/icons/342152047753166859/de4d258c0cab5bee0b04d406172ec585.jpg')
-		e.add_field(name='Name', value=team_data.team_name_short)
-		e.add_field(name='Rookie Year', value=team_data.rookie_year)
-		e.add_field(name='Location', value=', '.join((team_data.city, team_data.state_prov, team_data.country)))
-		e.add_field(name='Website', value=website or 'n/a')
-		e.add_field(name='Team Info Page', value='https://www.theorangealliance.org/teams/{}'.format(team_num))
-		e.set_footer(text='Triggered by ' + ctx.author.display_name)
-		await ctx.send(embed=e)
+        if team_data.error:
+            if team_num not in self._teams:
+                # rip
+                await ctx.send("This team does not have any data on it yet, or it does not exist!")
+                return
+            team_data._update(last_season)
+            team_data.team_name_short = last_season['name']
 
-	
-	team.example_usage = """
+        # many team entries lack a valid url
+        website = (team_data.website or last_season['website']).strip()
+        if website and not (website.startswith("http://") or website.startswith("https://")):
+            website = "http://" + website
+        e = discord.Embed(color=embed_color)
+        e.set_author(name='FIRST® Tech Challenge Team {}'.format(team_num),
+                     url='https://www.theorangealliance.org/teams/{}'.format(team_num),
+                     icon_url='https://cdn.discordapp.com/icons/342152047753166859/de4d258c0cab5bee0b04d406172ec585.jpg')
+        e.add_field(name='Name', value=team_data.team_name_short)
+        e.add_field(name='Rookie Year', value=team_data.rookie_year)
+        e.add_field(name='Location', value=', '.join((team_data.city, team_data.state_prov, team_data.country)))
+        e.add_field(name='Website', value=website or 'n/a')
+        e.add_field(name='Team Info Page', value='https://www.theorangealliance.org/teams/{}'.format(team_num))
+        e.set_footer(text='Triggered by ' + ctx.author.display_name)
+        await ctx.send(embed=e)
+
+    team.example_usage = """
 	`{prefix}toa team 12670` - show information on team 12670, Eclipse
 	"""
 
+
 def setup(bot):
-	bot.add_cog(TOA(bot))
+    bot.add_cog(TOA(bot))

--- a/dozer/cogs/voice.py
+++ b/dozer/cogs/voice.py
@@ -1,89 +1,98 @@
-from discord.ext.commands import has_permissions, bot_has_permissions
-from .. import db
-from ._utils import *
 import discord
+from discord.ext.commands import has_permissions, bot_has_permissions
+
+from ._utils import *
+from .. import db
+
 
 class Voice(Cog):
-	async def on_voice_state_update(self, member, before, after):
-		# skip this if we have no perms, or if it's something like a mute/deafen
-		if member.guild.me.guild_permissions.manage_roles and before.channel != after.channel:
-			# determine if it's a join/leave event as well.
-			# before and after are voice states
-			if after.channel is not None:
-				# join event, give role
-				with db.Session() as session:
-					config = session.query(Voicebinds).filter_by(channel_id=after.channel.id).one_or_none()
-					if config is not None:
-						await member.add_roles(discord.utils.get(member.guild.roles, id=config.role_id))
+    async def on_voice_state_update(self, member, before, after):
+        # skip this if we have no perms, or if it's something like a mute/deafen
+        if member.guild.me.guild_permissions.manage_roles and before.channel != after.channel:
+            # determine if it's a join/leave event as well.
+            # before and after are voice states
+            if after.channel is not None:
+                # join event, give role
+                with db.Session() as session:
+                    config = session.query(Voicebinds).filter_by(channel_id=after.channel.id).one_or_none()
+                    if config is not None:
+                        await member.add_roles(discord.utils.get(member.guild.roles, id=config.role_id))
 
-			if before.channel is not None:
-				# leave event, take role
-				with db.Session() as session:
-					config = session.query(Voicebinds).filter_by(channel_id=before.channel.id).one_or_none()
-					if config is not None:
-						await member.remove_roles(discord.utils.get(member.guild.roles, id=config.role_id))
+            if before.channel is not None:
+                # leave event, take role
+                with db.Session() as session:
+                    config = session.query(Voicebinds).filter_by(channel_id=before.channel.id).one_or_none()
+                    if config is not None:
+                        await member.remove_roles(discord.utils.get(member.guild.roles, id=config.role_id))
 
-	@command()
-	@bot_has_permissions(manage_roles=True)
-	@has_permissions(manage_roles=True)
-	async def voicebind(self, ctx, voice_channel : discord.VoiceChannel, *,  role : discord.Role):
-		"""Associates a voice channel with a role, so users joining a voice channel will automatically be given a specified role or roles."""
+    @command()
+    @bot_has_permissions(manage_roles=True)
+    @has_permissions(manage_roles=True)
+    async def voicebind(self, ctx, voice_channel: discord.VoiceChannel, *, role: discord.Role):
+        """Associates a voice channel with a role, so users joining a voice channel will automatically be given a specified role or roles."""
 
-		with db.Session() as session:
-			config = session.query(Voicebinds).filter_by(channel_id=voice_channel.id).one_or_none()
-			if config is not None:
-				config.guild_id = ctx.guild.id
-				config.channel_id = voice_channel.id
-				config.role_id = role.id
-			else:
-				config = Voicebinds(channel_id=voice_channel.id, role_id=role.id, guild_id=ctx.guild.id)
-				session.add(config)
-				
-		await ctx.send("Role `{role}` will now be given to users in voice channel `{voice_channel}`!".format(role=role, voice_channel=voice_channel))
+        with db.Session() as session:
+            config = session.query(Voicebinds).filter_by(channel_id=voice_channel.id).one_or_none()
+            if config is not None:
+                config.guild_id = ctx.guild.id
+                config.channel_id = voice_channel.id
+                config.role_id = role.id
+            else:
+                config = Voicebinds(channel_id=voice_channel.id, role_id=role.id, guild_id=ctx.guild.id)
+                session.add(config)
 
-	voicebind.example_usage = """
+        await ctx.send("Role `{role}` will now be given to users in voice channel `{voice_channel}`!".format(role=role,
+                                                                                                             voice_channel=voice_channel))
+
+    voicebind.example_usage = """
 	`{prefix}voicebind "General #1" voice-general-1` - sets up Dozer to give users  `voice-general-1` when they join voice channel "General #1", which will be removed when they leave.
 	"""
 
-	@command()
-	@bot_has_permissions(manage_roles=True)
-	@has_permissions(manage_roles=True)
-	async def voiceunbind(self, ctx, voice_channel : discord.VoiceChannel):
-		"""Dissasociates a voice channel with a role previously binded with the voicebind command."""
-		with db.Session() as session:
-			config = session.query(Voicebinds).filter_by(channel_id=voice_channel.id).one_or_none()
-			if config is not None:
-				role = discord.utils.get(ctx.guild.roles, id=config.role_id)
-				session.delete(config)
-				await ctx.send("Role `{role}` will no longer be given to users in voice channel `{voice_channel}`!".format(role=role, voice_channel=voice_channel))
-			else:
-				await ctx.send("It appears that `{voice_channel}` is not associated with a role!".format(voice_channel=voice_channel))
+    @command()
+    @bot_has_permissions(manage_roles=True)
+    @has_permissions(manage_roles=True)
+    async def voiceunbind(self, ctx, voice_channel: discord.VoiceChannel):
+        """Dissasociates a voice channel with a role previously binded with the voicebind command."""
+        with db.Session() as session:
+            config = session.query(Voicebinds).filter_by(channel_id=voice_channel.id).one_or_none()
+            if config is not None:
+                role = discord.utils.get(ctx.guild.roles, id=config.role_id)
+                session.delete(config)
+                await ctx.send(
+                    "Role `{role}` will no longer be given to users in voice channel `{voice_channel}`!".format(
+                        role=role, voice_channel=voice_channel))
+            else:
+                await ctx.send("It appears that `{voice_channel}` is not associated with a role!".format(
+                    voice_channel=voice_channel))
 
-	voiceunbind.example_usage = """
+    voiceunbind.example_usage = """
 	`{prefix}voiceunbind "General #1"` - Removes automatic role-giving for users in "General #1".
 	"""
-	
-	@command()
-	@bot_has_permissions(manage_roles=True)
-	async def voicebindlist(self, ctx):
-		"""Lists all the voice channel to role bindings for the current server"""
-		embed = discord.Embed(title="List of voice bindings for \"{}\"".format(ctx.guild), color=discord.Color.blue())
-		with db.Session() as session:
-			for config in session.query(Voicebinds).filter_by(guild_id=ctx.guild.id).all():
-				channel = discord.utils.get(ctx.guild.voice_channels, id=config.channel_id)
-				role = discord.utils.get(ctx.guild.roles, id=config.role_id)
-				embed.add_field(name=channel, value="`{}`".format(role))
-		await ctx.send(embed=embed)
-	voicebindlist.example_usage = """
+
+    @command()
+    @bot_has_permissions(manage_roles=True)
+    async def voicebindlist(self, ctx):
+        """Lists all the voice channel to role bindings for the current server"""
+        embed = discord.Embed(title="List of voice bindings for \"{}\"".format(ctx.guild), color=discord.Color.blue())
+        with db.Session() as session:
+            for config in session.query(Voicebinds).filter_by(guild_id=ctx.guild.id).all():
+                channel = discord.utils.get(ctx.guild.voice_channels, id=config.channel_id)
+                role = discord.utils.get(ctx.guild.roles, id=config.role_id)
+                embed.add_field(name=channel, value="`{}`".format(role))
+        await ctx.send(embed=embed)
+
+    voicebindlist.example_usage = """
 	`{prefix}voicebindlist` - Lists all the voice channel to role bindings for the current server bound with the voicebind command.
 	"""
 
+
 class Voicebinds(db.DatabaseObject):
-	__tablename__ = 'voicebinds'
-	id = db.Column(db.Integer, primary_key=True)
-	guild_id = db.Column(db.Integer)
-	channel_id = db.Column(db.Integer)
-	role_id = db.Column(db.Integer)
+    __tablename__ = 'voicebinds'
+    id = db.Column(db.Integer, primary_key=True)
+    guild_id = db.Column(db.Integer)
+    channel_id = db.Column(db.Integer)
+    role_id = db.Column(db.Integer)
+
 
 def setup(bot):
-	bot.add_cog(Voice(bot))
+    bot.add_cog(Voice(bot))

--- a/dozer/cogs/voice.py
+++ b/dozer/cogs/voice.py
@@ -45,8 +45,8 @@ class Voice(Cog):
                                                                                                              voice_channel=voice_channel))
 
     voicebind.example_usage = """
-	`{prefix}voicebind "General #1" voice-general-1` - sets up Dozer to give users  `voice-general-1` when they join voice channel "General #1", which will be removed when they leave.
-	"""
+    `{prefix}voicebind "General #1" voice-general-1` - sets up Dozer to give users  `voice-general-1` when they join voice channel "General #1", which will be removed when they leave.
+    """
 
     @command()
     @bot_has_permissions(manage_roles=True)
@@ -66,8 +66,8 @@ class Voice(Cog):
                     voice_channel=voice_channel))
 
     voiceunbind.example_usage = """
-	`{prefix}voiceunbind "General #1"` - Removes automatic role-giving for users in "General #1".
-	"""
+    `{prefix}voiceunbind "General #1"` - Removes automatic role-giving for users in "General #1".
+    """
 
     @command()
     @bot_has_permissions(manage_roles=True)
@@ -82,8 +82,8 @@ class Voice(Cog):
         await ctx.send(embed=embed)
 
     voicebindlist.example_usage = """
-	`{prefix}voicebindlist` - Lists all the voice channel to role bindings for the current server bound with the voicebind command.
-	"""
+    `{prefix}voicebindlist` - Lists all the voice channel to role bindings for the current server bound with the voicebind command.
+    """
 
 
 class Voicebinds(db.DatabaseObject):

--- a/dozer/db.py
+++ b/dozer/db.py
@@ -1,5 +1,5 @@
 import sqlalchemy
-from sqlalchemy import Column, Integer, String, ForeignKey, Boolean
+from sqlalchemy import Column, Integer, String, Boolean, ForeignKey, ForeignKeyConstraint
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship, Session, sessionmaker
 

--- a/dozer/db.py
+++ b/dozer/db.py
@@ -1,29 +1,32 @@
 import sqlalchemy
-from sqlalchemy import Column, Integer, String, ForeignKey, ForeignKeyConstraint, Boolean
+from sqlalchemy import Column, Integer, String, ForeignKey, Boolean
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship, Session, sessionmaker
 
-__all__ = ['engine', 'DatabaseObject', 'Session', 'Column', 'Integer', 'String', 'ForeignKey', 'relationship', 'Boolean']
+__all__ = ['engine', 'DatabaseObject', 'Session', 'Column', 'Integer', 'String', 'ForeignKey', 'relationship',
+           'Boolean']
 
 engine = sqlalchemy.create_engine('sqlite:///dozer.db')
 DatabaseObject = declarative_base(bind=engine, name='DatabaseObject')
-DatabaseObject.__table_args__ = {'extend_existing': True} #allow use of the reload command with db cogs
+DatabaseObject.__table_args__ = {'extend_existing': True}  # allow use of the reload command with db cogs
+
 
 class CtxSession(Session):
-	def __enter__(self):
-		return self
-	
-	async def __aenter__(self):
-		return self
-	
-	def __exit__(self, err_type, err, tb):
-		if err_type is None:
-			self.commit()
-		else:
-			self.rollback()
-		return False
-	
-	async def __aexit__(self, err_type, err, tb):
-		return self.__exit__(err_type, err, tb)
+    def __enter__(self):
+        return self
+
+    async def __aenter__(self):
+        return self
+
+    def __exit__(self, err_type, err, tb):
+        if err_type is None:
+            self.commit()
+        else:
+            self.rollback()
+        return False
+
+    async def __aexit__(self, err_type, err, tb):
+        return self.__exit__(err_type, err, tb)
+
 
 Session = sessionmaker(bind=engine, class_=CtxSession)

--- a/dozer/utils.py
+++ b/dozer/utils.py
@@ -1,4 +1,5 @@
-import discord, re
+import discord
+import re
 
 __all__ = ['clean', 'is_clean']
 
@@ -7,57 +8,63 @@ member_mention = re.compile(r'<@\!?(\d+)>')
 role_mention = re.compile(r'<@&(\d+)>')
 channel_mention = re.compile(r'<#(\d+)>')
 
+
 def clean(ctx, text=None, *, mass=True, member=True, role=True, channel=True):
-	if text is None:
-		text = ctx.message.content
-	if mass:
-		cleaned_text = mass_mention.sub(lambda match: '@\N{ZERO WIDTH SPACE}' + match.group(1), text)
-	if member:
-		cleaned_text = member_mention.sub(lambda match: clean_member_name(ctx, int(match.group(1))), cleaned_text)
-	if role:
-		cleaned_text = role_mention.sub(lambda match: clean_role_name(ctx, int(match.group(1))), cleaned_text)
-	if channel:
-		cleaned_text = channel_mention.sub(lambda match: clean_channel_name(ctx, int(match.group(1))), cleaned_text)
-	return cleaned_text
+    if text is None:
+        text = ctx.message.content
+    if mass:
+        cleaned_text = mass_mention.sub(lambda match: '@\N{ZERO WIDTH SPACE}' + match.group(1), text)
+    if member:
+        cleaned_text = member_mention.sub(lambda match: clean_member_name(ctx, int(match.group(1))), cleaned_text)
+    if role:
+        cleaned_text = role_mention.sub(lambda match: clean_role_name(ctx, int(match.group(1))), cleaned_text)
+    if channel:
+        cleaned_text = channel_mention.sub(lambda match: clean_channel_name(ctx, int(match.group(1))), cleaned_text)
+    return cleaned_text
+
 
 def is_clean(ctx, text=None):
-	if text is None:
-		text = ctx.message.content
-	return all(regex.search(text) is None for regex in (mass_mention, member_mention, role_mention, channel_mention))
+    if text is None:
+        text = ctx.message.content
+    return all(regex.search(text) is None for regex in (mass_mention, member_mention, role_mention, channel_mention))
+
 
 def clean_member_name(ctx, member_id):
-	member = ctx.guild.get_member(member_id)
-	if member is None:
-		return '<@\N{ZERO WIDTH SPACE}%d>' % member_id
-	elif is_clean(ctx, member.display_name):
-		return member.display_name
-	elif is_clean(ctx, str(member)):
-		return str(member)
-	else:
-		return '<@\N{ZERO WIDTH SPACE}%d>' % member.id
+    member = ctx.guild.get_member(member_id)
+    if member is None:
+        return '<@\N{ZERO WIDTH SPACE}%d>' % member_id
+    elif is_clean(ctx, member.display_name):
+        return member.display_name
+    elif is_clean(ctx, str(member)):
+        return str(member)
+    else:
+        return '<@\N{ZERO WIDTH SPACE}%d>' % member.id
+
 
 def clean_role_name(ctx, role_id):
-	role = discord.utils.get(ctx.guild.roles, id=role_id) # Guild.get_role doesn't exist
-	if role is None:
-		return '<@&\N{ZERO WIDTH SPACE}%d>' % role_id
-	elif is_clean(ctx, role.name):
-		return '@' + role.name
-	else:
-		return '<@&\N{ZERO WIDTH SPACE}%d>' % role.id
+    role = discord.utils.get(ctx.guild.roles, id=role_id)  # Guild.get_role doesn't exist
+    if role is None:
+        return '<@&\N{ZERO WIDTH SPACE}%d>' % role_id
+    elif is_clean(ctx, role.name):
+        return '@' + role.name
+    else:
+        return '<@&\N{ZERO WIDTH SPACE}%d>' % role.id
+
 
 def clean_channel_name(ctx, channel_id):
-	channel = ctx.guild.get_channel(channel_id)
-	if channel is None:
-		return '<#\N{ZERO WIDTH SPACE}%d>' % channel_id
-	elif is_clean(ctx, channel.name):
-		return '#' + channel.name
-	else:
-		return '<#\N{ZERO WIDTH SPACE}%d>' % channel.id
+    channel = ctx.guild.get_channel(channel_id)
+    if channel is None:
+        return '<#\N{ZERO WIDTH SPACE}%d>' % channel_id
+    elif is_clean(ctx, channel.name):
+        return '#' + channel.name
+    else:
+        return '<#\N{ZERO WIDTH SPACE}%d>' % channel.id
+
 
 def pretty_concat(strings, single_suffix='', multi_suffix=''):
-	if len(strings) == 1:
-		return strings[0] + single_suffix
-	elif len(strings) == 2:
-		return '{} and {}{}'.format(*strings, multi_suffix)
-	else:
-		return '{}, and {}{}'.format(', '.join(strings[:-1]), strings[-1], multi_suffix)
+    if len(strings) == 1:
+        return strings[0] + single_suffix
+    elif len(strings) == 2:
+        return '{} and {}{}'.format(*strings, multi_suffix)
+    else:
+        return '{}, and {}{}'.format(', '.join(strings[:-1]), strings[-1], multi_suffix)


### PR DESCRIPTION
Basically run through pycharm's reformatter and some glaring naming issues fixed (mostly in the moderation cog)

There's def more stuff not in pep8 compliance (mostly long lines), and much room for code cleanup, but since this is the main PR which switches Dozer from tabs to spaces, the faster this gets done and over with, the less merge conflicts happen....

oh btw this addresses #77 