### PR TITLE
Giveme roles now no longer list when deleted from server

### DIFF
--- a/dozer/cogs/roles.py
+++ b/dozer/cogs/roles.py
@@ -15,7 +15,7 @@ class Roles(Cog):
         for command in self.giveme.walk_commands():
             @command.before_invoke
             async def givemeautopurge(self, ctx):
-                if await self.ctxpurge(ctx):
+                if await self.ctx_purge(ctx):
                     await ctx.send("Purged missing roles")
 
     async def on_member_join(self, member):
@@ -70,14 +70,14 @@ class Roles(Cog):
             for role in member.roles[1:]:  # Exclude the @everyone role
                 db_member.missing_roles.append(MissingRole(role_id=role.id, role_name=role.name))
 
-    async def givemepurge(self, rolelist):
+    async def giveme_purge(self, rolelist):
         with db.Session() as session:
             for role in rolelist:
                 dbrole = session.query(GiveableRole).filter_by(id=role.id).one_or_none()
                 if dbrole is not None:
                     session.delete(dbrole)
 
-    async def ctxpurge(self, ctx):
+    async def ctx_purge(self, ctx):
         counter = 0
         with db.Session() as session:
             roles = session.query(GiveableRole).filter_by(guild_id=ctx.guild.id)
@@ -89,12 +89,12 @@ class Roles(Cog):
                 if role.id not in guildroles:
                     rolelist.append(role)
                     counter += 1
-        await self.givemepurge(rolelist)
+        await self.giveme_purge(rolelist)
         return counter
 
     async def on_guild_role_delete(self, role):
         rolelist = [role]
-        await self.givemepurge(rolelist)
+        await self.giveme_purge(rolelist)
 
     @group(invoke_without_command=True)
     @bot_has_permissions(manage_roles=True)
@@ -135,7 +135,7 @@ class Roles(Cog):
     @bot_has_permissions(manage_roles=True)
     @has_permissions(manage_roles=True)
     async def purge(self, ctx):
-        counter = await self.ctxpurge(ctx)
+        counter = await self.ctx_purge(ctx)
         await ctx.send("Purged {} role(s)".format(counter))
 
     @giveme.command()

--- a/dozer/cogs/roles.py
+++ b/dozer/cogs/roles.py
@@ -62,6 +62,13 @@ class Roles(Cog):
             for role in member.roles[1:]:  # Exclude the @everyone role
                 db_member.missing_roles.append(MissingRole(role_id=role.id, role_name=role.name))
 
+    async def on_guild_role_delete(self, role):
+        print(role)
+        with db.Session() as session:
+            dbrole = session.query(GiveableRole).filter_by(id=role.id).one_or_none()
+            if dbrole is not None:
+                session.delete(dbrole)
+
     @group(invoke_without_command=True)
     @bot_has_permissions(manage_roles=True)
     async def giveme(self, ctx, *, roles):


### PR DESCRIPTION
There have been multiple instances where  I've had to log into the DB to remove roles that have been deleted from the guild but not the giveme list, and this PR aims to put an end to that.