### PR TITLE
Invite command

### DIFF
--- a/dozer/cogs/general.py
+++ b/dozer/cogs/general.py
@@ -148,6 +148,17 @@ class General(Cog):
         if len(nicktochangeto) > 32:
             await ctx.send("Warning: truncated nickname to 32 characters")
 
+    @command()
+    async def invite(self, ctx):
+        """
+        Display the bot's invite link.
+        The generated link gives all permissions the bot requires. If permissions are removed, some commands will be unusable.
+        """
+        perms = 0
+        for cmd in sorted(set(ctx.bot.walk_commands()), key=lambda c: c.qualified_name):
+            perms |= cmd.required_permissions.value
+        await ctx.send('<{}>'.format(discord.utils.oauth_url(ctx.me.id, discord.Permissions(perms))))
+
     @has_permissions(create_instant_invite=True)
     @bot_has_permissions(create_instant_invite=True)
     @command()

--- a/dozer/cogs/general.py
+++ b/dozer/cogs/general.py
@@ -1,6 +1,6 @@
 import discord
 import inspect
-from discord.ext.commands import BadArgument, bot_has_permissions, cooldown, BucketType, Group, has_permissions
+from discord.ext.commands import BadArgument, cooldown, BucketType, Group, has_permissions
 
 from ._utils import *
 from .. import db

--- a/dozer/cogs/general.py
+++ b/dozer/cogs/general.py
@@ -155,7 +155,7 @@ class General(Cog):
         The generated link gives all permissions the bot requires. If permissions are removed, some commands will be unusable.
         """
         perms = 0
-        for cmd in sorted(set(ctx.bot.walk_commands()), key=lambda c: c.qualified_name):
+        for cmd in ctx.bot.walk_commands():
             perms |= cmd.required_permissions.value
         await ctx.send('<{}>'.format(discord.utils.oauth_url(ctx.me.id, discord.Permissions(perms))))
 

--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -3,7 +3,7 @@ import discord
 import re
 import datetime
 
-from discord.ext.commands import BadArgument, has_permissions, bot_has_permissions, RoleConverter
+from discord.ext.commands import BadArgument, has_permissions, RoleConverter
 
 from ._utils import *
 from .. import db

--- a/dozer/cogs/namegame.py
+++ b/dozer/cogs/namegame.py
@@ -7,7 +7,7 @@ from functools import wraps
 
 import discord
 import tbapi
-from discord.ext.commands import bot_has_permissions, has_permissions
+from discord.ext.commands import has_permissions
 from fuzzywuzzy import fuzz
 
 from dozer.bot import logger

--- a/dozer/cogs/roles.py
+++ b/dozer/cogs/roles.py
@@ -1,6 +1,6 @@
 import discord
 import discord.utils
-from discord.ext.commands import bot_has_permissions, cooldown, BucketType, has_permissions, BadArgument
+from discord.ext.commands import cooldown, BucketType, has_permissions, BadArgument
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 
 from ._utils import *

--- a/dozer/cogs/tba.py
+++ b/dozer/cogs/tba.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 import discord
 import googlemaps
 import tbapi
-from discord.ext.commands import BadArgument, bot_has_permissions
+from discord.ext.commands import BadArgument
 from geopy.geocoders import Nominatim
 
 from ._utils import *

--- a/dozer/cogs/toa.py
+++ b/dozer/cogs/toa.py
@@ -2,7 +2,6 @@ import gzip
 import pickle
 
 import discord
-from discord.ext.commands import bot_has_permissions
 
 from ._toa import *
 from ._utils import *

--- a/dozer/cogs/voice.py
+++ b/dozer/cogs/voice.py
@@ -1,5 +1,5 @@
 import discord
-from discord.ext.commands import has_permissions, bot_has_permissions
+from discord.ext.commands import has_permissions
 
 from ._utils import *
 from .. import db


### PR DESCRIPTION
Keeping track of what permissions the bot requires involved replacing the default `bot_has_permissions` decorator with one that sets an attribute on the command with the required permissions. This also required putting `CommandMixin` at the front of `Command` and `Group`'s base classes, since discordpy's `Command` and `Group` don't call the superclasses' `__init__` methods.