### PR TITLE
Pin discord.py version to a known-working commit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-https://github.com/Rapptz/discord.py/archive/rewrite.zip#egg=discord.py
+git+https://github.com/Rapptz/discord.py@3f06f247c039a23948e7bb0014ea31db533b4ba2#egg=discord.py
 sqlalchemy
 tbapi==1.3.1b4
 aiotba


### PR DESCRIPTION
In preparation for version 1.0, the rewrite branch of discord.py underwent significant breaking changes. Existing installations are fine, but new installations will fail to start.

Now that 1.0 is out, the rewrite branch has been deleted. Running `pip -Ur requirements.txt` now fails with `HTTP error 404 while getting https://github.com/Rapptz/discord.py/archive/rewrite.zip#egg=discord.py`.

This PR solves both of these issues by pinning our discord.py version to the last commit before the breaking changes started, which still exists on master.