### PR TITLE
Fixed error requiring bot restart to apply messagelog

### DIFF
--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -724,7 +724,7 @@ class Moderation(Cog):
         else:
             config = GuildMessageLog(guild_id=ctx.guild.id, messagelog_channel=channel_mentions.id, name=ctx.guild.name)
         await config.update_or_add()
-        # self.edit_delete_config.invalidate_entry(id=ctx.guild.id)
+        self.edit_delete_config.invalidate_entry(id=ctx.guild.id)
         await ctx.send(ctx.message.author.mention + ', messagelog settings configured!')
     messagelogconfig.example_usage = """
     `{prefix}messagelogconfig #orwellian-dystopia` - set a channel named #orwellian-dystopia to log message edits/deletions


### PR DESCRIPTION
This line got commented out during the DB rewrite and never uncommented, whoops