### PR TITLE
New embeds for message logs

### DIFF
--- a/dozer/__main__.py
+++ b/dozer/__main__.py
@@ -60,7 +60,7 @@ from . import Dozer  # After version check
 intents = discord.Intents.default()
 intents.members = True
 
-bot = Dozer(config, intents=intents)
+bot = Dozer(config, intents=intents, max_messages=5000)
 
 for ext in os.listdir('dozer/cogs'):
     if not ext.startswith(('_', '.')):

--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -366,7 +366,7 @@ class Moderation(Cog):
         channel_id = str(payload.channel_id)
         user_id = str(author['id'])
         if (self.bot.get_user(int(author['id']))).bot:
-            return
+            return  # Breakout if the user is a bot
         message_id = str(payload.message_id)
         link = f"https://discordapp.com/channels/{str(guild_id)}/{str(channel_id)}/{str(message_id)}"
         mention = f"<@!{user_id}>"
@@ -392,7 +392,7 @@ class Moderation(Cog):
     async def on_message_edit(self, before, after):
         """Logs message edits."""
         await self.check_links(after)
-        if before.author.bot:
+        if before.author.bot or after.author.bot:
             return
         if after.edited_at is not None or before.edited_at is not None:
             # There is a reason for this. That reason is that otherwise, an infinite spam loop occurs

--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -376,7 +376,9 @@ class Moderation(Cog):
         embed.set_thumbnail(url=avatar_link)
         embed.add_field(name="Original", value="N/A", inline=False)
         if content:
-            embed.add_field(name="Edited", value=str(content), inline=False)
+            embed.add_field(name="Edited", value=str(content[0:1023]), inline=False)
+            if len(content) > 1024:
+                embed.add_field(name="Edited Continued", value=str(content[1024:2000]), inline=False)
         else:
             embed.add_field(name="Edited", value="N/A", inline=False)
         embed.set_footer(text="UserID: " + str(user_id))
@@ -399,7 +401,7 @@ class Moderation(Cog):
             user_id = str(before.author.id)
             message_id = str(before.id)
             link = f"https://discordapp.com/channels/{str(guild_id)}/{str(channel_id)}/{str(message_id)}"
-            embed = discord.Embed(title="Message Edit Log",
+            embed = discord.Embed(title="Message Edited",
                                   description=f"[MESSAGE]({link}) From {before.author.mention}"
                                               f"\nEdited In: {str(before.channel.mention)}", color=0xFFC400,
                                   timestamp=after.edited_at)

--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -311,9 +311,9 @@ class Moderation(Cog):
                               color=0xFF00F0, timestamp=message_created)
         embed.add_field(name="Message", value="N/A", inline=False)
         embed.set_footer(text=f"MessageID: {str(message_id)}; Sent at")
-        messagelogchannel = await self.edit_delete_config.query_one(guild_id=guild.id)
-        if messagelogchannel is not None:
-            channel = guild.get_channel(messagelogchannel.messagelog_channel)
+        message_log_channel = await self.edit_delete_config.query_one(guild_id=guild.id)
+        if message_log_channel is not None:
+            channel = guild.get_channel(message_log_channel.messagelog_channel)
             if channel is not None:
                 await channel.send(embed=embed)
 
@@ -340,9 +340,9 @@ class Moderation(Cog):
         embed.set_footer(text="UserID:" + str(message.author.id))
         if message.attachments:
             embed.add_field(name="Attachments", value=", ".join([i.url for i in message.attachments]))
-        messagelogchannel = await self.edit_delete_config.query_one(guild_id=message.guild.id)
-        if messagelogchannel is not None:
-            channel = message.guild.get_channel(messagelogchannel.messagelog_channel)
+        message_log_channel = await self.edit_delete_config.query_one(guild_id=message.guild.id)
+        if message_log_channel is not None:
+            channel = message.guild.get_channel(message_log_channel.messagelog_channel)
             if channel is not None:
                 await channel.send(embed=embed)
 
@@ -382,9 +382,9 @@ class Moderation(Cog):
         else:
             embed.add_field(name="Edited", value="N/A", inline=False)
         embed.set_footer(text="UserID: " + str(user_id))
-        messagelogchannel = await self.edit_delete_config.query_one(guild_id=guild.id)
-        if messagelogchannel is not None:
-            channel = guild.get_channel(messagelogchannel.messagelog_channel)
+        message_log_channel = await self.edit_delete_config.query_one(guild_id=guild.id)
+        if message_log_channel is not None:
+            channel = guild.get_channel(message_log_channel.messagelog_channel)
             if channel is not None:
                 await channel.send(embed=embed)
 
@@ -419,9 +419,9 @@ class Moderation(Cog):
             embed.set_footer(text="UserID:" + str(user_id))
             if after.attachments:
                 embed.add_field(name="Attachments", value=", ".join([i.url for i in before.attachments]))
-            messagelogchannel = await self.edit_delete_config.query_one(guild_id=before.guild.id)
-            if messagelogchannel is not None:
-                channel = before.guild.get_channel(messagelogchannel.messagelog_channel)
+            message_log_channel = await self.edit_delete_config.query_one(guild_id=before.guild.id)
+            if message_log_channel is not None:
+                channel = before.guild.get_channel(message_log_channel.messagelog_channel)
                 if channel is not None:
                     await channel.send(embed=embed)
 

--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -325,9 +325,9 @@ class Moderation(Cog):
             return
         audit = await self.check_audit(message.guild)
         embed = discord.Embed(title="Message Deleted",
-                              description=f"Message Deleted In: {message.channel.mention}\nSent by: {message.author.mention} ({message.author.name})",
+                              description=f"Message Deleted In: {message.channel.mention}\nSent by: {message.author.mention}",
                               color=0xFF0000, timestamp=message.created_at)
-        embed.set_thumbnail(url=message.author.avatar_url)
+        embed.set_author(name=message.author, icon_url=message.author.avatar_url)
         if audit:
             if audit.target == f"{message.author.name}#{message.author.discriminator}":
                 audit_member = await message.guild.fetch_member(audit.user.id)
@@ -370,7 +370,7 @@ class Moderation(Cog):
         avatar_link = f"http://cdn.discordapp.com/avatars/{user_id}/{author['avatar']}.webp?size=1024"
         embed = discord.Embed(title="Message Edited",
                               description=f"[MESSAGE]({link}) From {mention}\nEdited In: {mchannel.mention}", color=0xFFC400)
-        embed.set_thumbnail(url=avatar_link)
+        embed.set_author(name=f"{author['username']}#{author['discriminator']}",icon_url=avatar_link)
         embed.add_field(name="Original", value="N/A", inline=False)
         if content:
             embed.add_field(name="Edited", value=content[0:1023], inline=False)
@@ -402,7 +402,7 @@ class Moderation(Cog):
                                   description=f"[MESSAGE]({link}) From {before.author.mention}"
                                               f"\nEdited In: {before.channel.mention}", color=0xFFC400,
                                   timestamp=after.edited_at)
-            embed.set_thumbnail(url=after.author.avatar_url)
+            embed.set_author(name=before.author, icon_url=before.author.avatar_url)
             if before.content:
                 embed.add_field(name="Original", value=before.content[0:1023], inline=False)
                 if len(before.content) > 1024:

--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -329,9 +329,9 @@ class Moderation(Cog):
                               color=0xFF0000, timestamp=message.created_at)
         embed.set_author(name=message.author, icon_url=message.author.avatar_url)
         if audit:
-            if audit.target == f"{message.author.name}#{message.author.discriminator}":
+            if audit.target == message.author:
                 audit_member = await message.guild.fetch_member(audit.user.id)
-                embed.add_field(name="Message Deleted By: ", value=audit_member.mention, inline=False)
+                embed.add_field(name="Message Deleted By: ", value=str(audit_member.mention), inline=False)
         if message.content:
             embed.add_field(name="Message Content:", value=message.content[0:1023], inline=False)
             if len(message.content) > 1024:

--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -254,9 +254,9 @@ class Moderation(Cog):
         join.set_author(name='Member Joined', icon_url=member.avatar_url_as(format='png', size=32))
         join.description = "{0.mention}\n{0} ({0.id})".format(member)
         join.set_footer(text="{} | {} members".format(member.guild.name, member.guild.member_count))
-        memberlogchannel = await GuildMemberLog.get_by(guild_id=member.guild.id)
-        if len(memberlogchannel) != 0:
-            channel = member.guild.get_channel(memberlogchannel[0].memberlog_channel)
+        member_log_channel = await GuildMemberLog.get_by(guild_id=member.guild.id)
+        if len(member_log_channel) != 0:
+            channel = member.guild.get_channel(member_log_channel[0].memberlog_channel)
             await channel.send(embed=join)
         users = await Mute.get_by(guild_id=member.guild.id, member_id=member.id)
         if users:
@@ -272,9 +272,9 @@ class Moderation(Cog):
         leave.set_author(name='Member Left', icon_url=member.avatar_url_as(format='png', size=32))
         leave.description = "{0.mention}\n{0} ({0.id})".format(member)
         leave.set_footer(text="{} | {} members".format(member.guild.name, member.guild.member_count))
-        memberlogchannel = await GuildMemberLog.get_by(guild_id=member.guild.id)
-        if len(memberlogchannel) != 0:
-            channel = member.guild.get_channel(memberlogchannel[0].memberlog_channel)
+        member_log_channel = await GuildMemberLog.get_by(guild_id=member.guild.id)
+        if len(member_log_channel) != 0:
+            channel = member.guild.get_channel(member_log_channel[0].memberlog_channel)
             await channel.send(embed=leave)
 
     @Cog.listener('on_message')
@@ -303,11 +303,11 @@ class Moderation(Cog):
         if payload.cached_message:
             return
         guild = self.bot.get_guild(int(payload.guild_id))
-        Mchannel = self.bot.get_channel(int(payload.channel_id))
+        message_channel = self.bot.get_channel(int(payload.channel_id))
         message_id = int(payload.message_id)
         message_created = discord.Object(message_id).created_at
         embed = discord.Embed(title="Message Deleted",
-                              description="Message Deleted In: " + str(Mchannel.mention),
+                              description="Message Deleted In: " + str(message_channel.mention),
                               color=0xFF00F0, timestamp=message_created)
         embed.add_field(name="Message", value="N/A", inline=False)
         embed.set_footer(text=f"MessageID: {str(message_id)}; Sent at")

--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -39,6 +39,7 @@ class Moderation(Cog):
 
     @staticmethod
     async def check_audit(guild, event_time=None):
+        """Method for checking the audit log for events"""
         async for entry in guild.audit_logs(limit=1, before=event_time, action=discord.AuditLogAction.message_delete):
             return entry
 

--- a/pylintrc
+++ b/pylintrc
@@ -515,7 +515,7 @@ max-locals=20
 max-parents=7
 
 # Maximum number of public methods for a class (see R0904).
-max-public-methods=30
+max-public-methods=40
 
 # Maximum number of return / yield for function / method body
 max-returns=6


### PR DESCRIPTION
I spent some time formatting the embeds for message logs, and added a method for handing raw api payloads in the event a message wasn't in the cache. I also increased the message cache size from 1000 to 5000 which is still quite low for a discord bot of dozers scale