### PR TITLE
Have filter check if author has a roles attribute

### DIFF
--- a/dozer/cogs/filter.py
+++ b/dozer/cogs/filter.py
@@ -48,7 +48,7 @@ class Filter(Cog):
 
     async def check_filters(self, message):
         """Check all the filters for a certain message (with it's guild)"""
-        if message.author.id == self.bot.user.id:
+        if message.author.id == self.bot.user.id or not hasattr(message.author, 'roles'):
             return
         roles = await self.word_filter_role_whitelist.query_all(guild_id=message.guild.id)
         whitelisted_ids = set(role.role_id for role in roles)


### PR DESCRIPTION
If this line of code isn't in there, the Dozer log is spammed with all sorts of errors whenever the author is a `User` instead of a `Member`, which happens in DMs or with certain kinds of connections.