### PR TITLE
Switch CI to GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
           python-version: '3.8.2'
 
       - name: Install dependencies
-        run: pip install pylint && pip install -r requirements.txt
+        run: pip install pylint wheel -r requirements.txt
 
       # Runs a set of commands using the runners shell
       - name: Lint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,25 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8.2'
+
+      - name: Install dependencies
+        run: pip install pylint && pip install -r requirements.txt
+
+      # Runs a set of commands using the runners shell
+      - name: Lint
+        run: ci/ci.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: python
-python: 3.8.2
-cache:
-  pip: true
-install:
-  - pip install pylint
-  - pip install -r requirements.txt
-script: ./ci/ci.sh


### PR DESCRIPTION
With the apparent removal of the TravisCI open source plan, we will be switching to GitHub Actions. @octocynth don't forget to disable TravisCI