### PR TITLE
Levels feature 2

### DIFF
--- a/dozer/cogs/levels.py
+++ b/dozer/cogs/levels.py
@@ -345,6 +345,7 @@ class Levels(Cog):
     `{prefix}configureranks xprange 5 15`: Sets the xp range
     `{prefix}configureranks setcooldown 15`: Sets the cooldown time in seconds
     `{prefix}configureranks toggle`: Toggles levels
+    `{prefix}configureranks keeproles`: Toggles whenever old level role roles will be kept on level up
     `{prefix}configureranks notificationchannel channel`: Sets level up message channel
     `{prefix}configureranks notificationsoff`: Turns off notification channel
     `{prefix}configureranks setrolelevel role level`: Adds a level role
@@ -382,7 +383,7 @@ class Levels(Cog):
     @guild_only()
     @has_permissions(manage_guild=True)
     async def keeproles(self, ctx):
-        """Toggle dozer ranks"""
+        """Toggles whenever old level role roles will be kept on level up"""
         await self._cfg_guild_setting(ctx, keep_old_roles_toggle=True)
 
     @configureranks.command(aliases=["notifications"])

--- a/dozer/cogs/levels.py
+++ b/dozer/cogs/levels.py
@@ -93,9 +93,10 @@ class Levels(Cog):
     async def check_new_roles(self, guild, member, cached_member, guild_settings):
         """Check and see if a member has qualified to get a new role"""
         current_level = self.level_for_total_xp(cached_member.total_xp)
-        roles = sorted(self._level_roles.get(guild.id) if self._level_roles.get(guild.id) else [], key=lambda entry: entry.level)
+        unsorted = self._level_roles.get(guild.id)
 
-        if roles:
+        if unsorted:
+            roles = sorted(unsorted, key=lambda entry: entry.level)
             add_roles = []
             del_roles = []
 
@@ -114,7 +115,6 @@ class Levels(Cog):
                     del_roles.append(del_role)
 
             try:
-
                 await member.add_roles(*add_roles, reason="Level Up")
                 if not guild_settings.keep_old_roles:
                     await member.remove_roles(*del_roles, reason="Level Up")

--- a/dozer/cogs/levels.py
+++ b/dozer/cogs/levels.py
@@ -93,7 +93,7 @@ class Levels(Cog):
     async def check_new_roles(self, guild, member, cached_member, guild_settings):
         """Check and see if a member has qualified to get a new role"""
         current_level = self.level_for_total_xp(cached_member.total_xp)
-        roles = sorted(self._level_roles.get(guild.id), key=lambda entry: entry.level)
+        roles = sorted(self._level_roles.get(guild.id) if self._level_roles.get(guild.id) else [], key=lambda entry: entry.level)
 
         if roles:
             add_roles = []


### PR DESCRIPTION
Added pagination and keep roles

Important in order to deploy this sql command will need to be run

`ALTER TABLE levels_guild_settings
ADD COLUMN keep_old_roles boolean NOT NULL default TRUE;`

Close #228 
Close #229 