### PR TITLE
Added cache size to the config file and set the default to 20,000

### DIFF
--- a/dozer/__main__.py
+++ b/dozer/__main__.py
@@ -13,6 +13,7 @@ from . import db
 
 config = {
     'prefix': '&', 'developers': [],
+    'cache_size': 20000,
     'tba': {
         'key': ''
     },
@@ -61,7 +62,7 @@ intents = discord.Intents.default()
 intents.members = True
 intents.presences = True
 
-bot = Dozer(config, intents=intents, max_messages=5000)
+bot = Dozer(config, intents=intents, max_messages=config['cache_size'])
 
 for ext in os.listdir('dozer/cogs'):
     if not ext.startswith(('_', '.')):


### PR DESCRIPTION
The new default is at 20,000 but this can of course be adjusted based on hosting capability's, I did some testing and it appears that every 5000 messages uses approx 50mb of memory so the cache could probably be increased even higher on dozer. 

Signed-off-by: AidanFromProgramming <46631427+AidanFromProgramming@users.noreply.github.com>