### PR TITLE
Levels patch 3.1

### DIFF
--- a/dozer/cogs/levels.py
+++ b/dozer/cogs/levels.py
@@ -311,8 +311,7 @@ class Levels(Cog):
             await paginate(ctx, embeds)
         else:
             embed.description = "This server has no level roles assigned"
-
-        await ctx.send(embed=embed)
+            await ctx.send(embed=embed)
 
     checkrolelevels.example_usage = """
     `{prefix}checkrolelevels`: Returns an embed of all the role levels 


### PR DESCRIPTION
Tab'd over a line to stop dozer from sending an extra empty embed during checkroles 

Signed-off-by: AidanFromProgramming <46631427+AidanFromProgramming@users.noreply.github.com>