### PR TITLE
Fix race condition of two reactions in quick succession for starboard

### DIFF
--- a/dozer/cogs/starboard.py
+++ b/dozer/cogs/starboard.py
@@ -10,6 +10,8 @@ from ._utils import *
 from .. import db
 
 MAX_EMBED = 1024
+LOCK_TIME = .1
+FORCE_TRY_TIME = 1
 DOZER_LOGGER = logging.getLogger('dozer')
 VIDEO_FORMATS = ['.mp4', '.mov', 'webm']
 
@@ -127,8 +129,10 @@ class Starboard(Cog):
         if not msg.guild:
             return
 
-        while msg in self.locked_messages:
-            await asyncio.sleep(.1)
+        time_waiting = 0
+        while msg in self.locked_messages or time_waiting > FORCE_TRY_TIME:
+            await asyncio.sleep(LOCK_TIME)
+            time_waiting += LOCK_TIME
         self.locked_messages.add(msg)
 
         config = await self.config_cache.query_one(guild_id=msg.guild.id)

--- a/dozer/cogs/starboard.py
+++ b/dozer/cogs/starboard.py
@@ -134,7 +134,7 @@ class Starboard(Cog):
             return
 
         time_waiting = 0
-        while msg in self.locked_messages or time_waiting > FORCE_TRY_TIME:
+        while msg in self.locked_messages and time_waiting < FORCE_TRY_TIME:
             await asyncio.sleep(LOCK_TIME)
             time_waiting += LOCK_TIME
         self.locked_messages.add(msg)

--- a/dozer/cogs/starboard.py
+++ b/dozer/cogs/starboard.py
@@ -129,15 +129,15 @@ class Starboard(Cog):
         if not msg.guild:
             return
 
+        config = await self.config_cache.query_one(guild_id=msg.guild.id)
+        if config is None:
+            return
+
         time_waiting = 0
         while msg in self.locked_messages or time_waiting > FORCE_TRY_TIME:
             await asyncio.sleep(LOCK_TIME)
             time_waiting += LOCK_TIME
         self.locked_messages.add(msg)
-
-        config = await self.config_cache.query_one(guild_id=msg.guild.id)
-        if config is None:
-            return
 
         self_react = 0
         if await is_cancelled(config.star_emoji, msg, msg.guild.me, msg.guild.me):


### PR DESCRIPTION
Does what it says on the tin, adds a local message lock to the starboard logic that will only let a message be processed once, eliminating the race condition of two reactions in quick succession meaning the message gets posted twice.