### PR TITLE
Reaction roles patch 1

### DIFF
--- a/dozer/cogs/general.py
+++ b/dozer/cogs/general.py
@@ -195,6 +195,3 @@ def setup(bot):
     """Adds the general cog to the bot"""
     bot.remove_command('help')
     bot.add_cog(General(bot))
-
-
-

--- a/dozer/cogs/roles.py
+++ b/dozer/cogs/roles.py
@@ -68,8 +68,9 @@ class Roles(Cog):
     async def on_raw_message_delete(self, payload):
         """Used to remove dead reaction role entries"""
         message_id = payload.message_id
+        entry = await ReactionRole.get_by(message_id=message_id)
         await ReactionRole.delete(message_id=message_id)
-        self.reaction_roles.invalidate_entry(message_id=message_id)
+        self.remove_from_cache(entry[0])
         await RoleMenu.delete(message_id=message_id)
 
     @Cog.listener()


### PR DESCRIPTION
Fixed issue where invalidate cache wasn't invalidating the correct entries resulting in reaction role add not updating the menus correctly, and just all around not working