### PR TITLE
Reduce selfdeafen spam

### DIFF
--- a/dozer/bot.py
+++ b/dozer/bot.py
@@ -98,8 +98,12 @@ class Dozer(commands.Bot):
             await context.send(
                 '{}, That command is on cooldown! Try again in {:.2f}s!'.format(context.author.mention, exception.retry_after))
         elif isinstance(exception, commands.MaxConcurrencyReached):
+            types = {discord.ext.commands.BucketType.default: "`Global`", discord.ext.commands.BucketType.guild: "`Guild`",
+                     discord.ext.commands.BucketType.channel: "`Channel`", discord.ext.commands.BucketType.category: "`Category`",
+                     discord.ext.commands.BucketType.member: "`Member`", discord.ext.commands.BucketType.user: "`User`"}
             await context.send(
-                '{}, That command is already running more instances than allowed! Please try again later'.format(context.author.mention))
+                '{}, That command has exceeded the max {} concurrency limit of `{}` instance! Please try again later.'.format(
+                    context.author.mention, types[exception.per], exception.number))
         elif isinstance(exception, (commands.CommandNotFound, InvalidContext)):
             pass  # Silent ignore
         else:

--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -505,12 +505,16 @@ class Moderation(Cog):
     """
 
     @command()
-    @bot_has_permissions(manage_roles=True)
+    @bot_has_permissions(manage_roles=True)  # Once instance globally, don't wait instead throw exception
+    @discord.ext.commands.max_concurrency(1, wait=False, per=discord.ext.commands.BucketType.default)
+    @discord.ext.commands.cooldown(rate=10, per=2, type=discord.ext.commands.BucketType.guild)  # 10 seconds per 2 members in the guild
     async def selfdeafen(self, ctx, *, reason="No reason provided"):
         """Deafen yourself for a given time period to prevent you from reading or sending messages; useful as a study tool."""
         async with ctx.typing():
             seconds = self.hm_to_seconds(reason)
             reason = self.hm_regex.sub("", reason) or "No reason provided"
+            if seconds < 300:
+                raise BadArgument("You must self deafen yourself for at least 5 minutes!")
             if await self._deafen(ctx.author, reason, seconds=seconds, self_inflicted=True, actor=ctx.author, orig_channel=ctx.channel):
                 await self.mod_log(ctx.author, "deafened", ctx.author, reason, ctx.channel, discord.Color.red(), global_modlog=False,
                                    duration=datetime.timedelta(seconds=seconds))


### PR DESCRIPTION
Added more detail to max concurrency error, and added min selfdeafen time and ratelimits to selfdeafen to reduce api spam

Close #283 

Signed-off-by: Aidan <aidanfromprogramming@gmail.com>