### PR TITLE
The Great f-Stringification

### DIFF
--- a/dozer/Components/CustomJoinLeaveMessages.py
+++ b/dozer/Components/CustomJoinLeaveMessages.py
@@ -14,7 +14,7 @@ async def send_log(member):
             embed = discord.Embed(color=0x00FF00)
             embed.set_author(name='Member Joined', icon_url=member.display_avatar.replace(format='png', size=32))
             embed.description = format_join_leave(config[0].join_message, member)
-            embed.set_footer(text="{} | {} members".format(member.guild.name, member.guild.member_count))
+            embed.set_footer(text=f"{member.guild.name} | {member.guild.member_count} members")
             try:
                 await channel.send(content=member.mention if config[0].ping else None, embed=embed)
             except discord.Forbidden:
@@ -30,12 +30,9 @@ def format_join_leave(template: str, member: discord.Member):
     {user_mention} = user's mention
     {user_id} = user's ID
     """
-    if template:
-        return template.format(guild=member.guild, user=str(member), user_name=member.name,
-                               user_mention=member.mention, user_id=member.id)
-    else:
-        return "{user_mention}\n{user} ({user_id})".format(user=str(member), user_mention=member.mention,
-                                                           user_id=member.id)
+    template = template or "{user_mention}\n{user} ({user_id})"
+    return template.format(guild=member.guild, user=str(member), user_name=member.name,
+                            user_mention=member.mention, user_id=member.id)
 
 
 class CustomJoinLeaveMessages(db.DatabaseTable):

--- a/dozer/__main__.py
+++ b/dozer/__main__.py
@@ -8,6 +8,9 @@ import discord
 import sentry_sdk
 from loguru import logger
 
+if sys.version_info < (3, 8):
+    sys.exit('Dozer requires Python 3.8 or higher to run. This is version ' + '.'.join(sys.version_info[:3]) + '.')
+
 config = {
     'prefix': '&', 'developers': [],
     'cache_size': 20000,
@@ -70,9 +73,6 @@ logger.add(sys.stdout, format=logger_format, level="DEBUG" if config['debug'] el
 
 if 'discord_token' not in config:
     sys.exit('Discord token must be supplied in configuration')
-
-if sys.version_info < (3, 8):
-    sys.exit('Dozer requires Python 3.8 or higher to run. This is version %s.' % '.'.join(sys.version_info[:3]))
 
 from . import Dozer  # After version check
 

--- a/dozer/bot.py
+++ b/dozer/bot.py
@@ -20,10 +20,8 @@ from .db import db_init, db_migrate
 
 if discord.version_info.major < 2:
     logger.error("Your installed discord.py version is too low "
-                 "%d.%d.%d, please upgrade to at least 2.0.0",
-                 discord.version_info.major,
-                 discord.version_info.minor,
-                 discord.version_info.micro)
+                 "{vi.major}.{vi.minor}.{vi.micro}, please upgrade to at least 2.0.0".format(
+                   vi=discord.version_info))
     sys.exit(1)
 
 
@@ -58,7 +56,7 @@ class Dozer(commands.Bot):
     async def on_ready(self):
         """Things to run when the bot has initialized and signed in"""
 
-        logger.info('Signed in as {}#{} ({})'.format(self.user.name, self.user.discriminator, self.user.id))
+        logger.info(f'Signed in as {self.user.name}#{self.user.discriminator} ({self.user.id})')
         news_cog = self.get_cog("News")
         await news_cog.startup()
         await self.dynamic_prefix.refresh()
@@ -68,7 +66,7 @@ class Dozer(commands.Bot):
                 perms |= cmd.required_permissions.value
             else:
                 logger.warning(f"Command {cmd} not subclass of Dozer type.")
-        logger.debug('Bot Invite: {}'.format(utils.oauth_url(self.user.id, discord.Permissions(perms))))
+        logger.debug(f'Bot Invite: {utils.oauth_url(self.user.id, discord.Permissions(perms))}')
         if self.config['is_backup']:
             status = discord.Status.dnd
         else:
@@ -86,25 +84,21 @@ class Dozer(commands.Bot):
 
     async def on_command_error(self, context: DozerContext, exception):  # pylint: disable=arguments-differ
         if isinstance(exception, commands.NoPrivateMessage):
-            await context.send('{}, This command cannot be used in DMs.'.format(context.author.mention))
+            await context.send(f'{context.author.mention}, This command cannot be used in DMs.')
         elif isinstance(exception, commands.UserInputError):
-            await context.send('{}, {}'.format(context.author.mention, self.format_error(context, exception)))
+            await context.send(f'{context.author.mention}, {self.format_error(context, exception)}')
         elif isinstance(exception, commands.NotOwner):
-            await context.send('{}, {}'.format(context.author.mention, exception.args[0]))
+            await context.send(f'{context.author.mention}, {exception.args[0]}')
         elif isinstance(exception, commands.MissingPermissions):
             permission_names = [name.replace('guild', 'server').replace('_', ' ').title() for name in
                                 exception.missing_permissions]
-            await context.send('{}, you need {} permissions to run this command!'.format(
-                context.author.mention, utils.pretty_concat(permission_names)))
+            await context.send(f'{context.author.mention}, you need {utils.pretty_concat(permission_names)} permissions to run this command!')
         elif isinstance(exception, commands.BotMissingPermissions):
             permission_names = [name.replace('guild', 'server').replace('_', ' ').title() for name in
                                 exception.missing_permissions]
-            await context.send('{}, I need {} permissions to run this command!'.format(
-                context.author.mention, utils.pretty_concat(permission_names)))
+            await context.send(f'{context.author.mention}, I need {utils.pretty_concat(permission_names)} permissions to run this command!')
         elif isinstance(exception, commands.CommandOnCooldown):
-            await context.send(
-                '{}, That command is on cooldown! Try again in {:.2f}s!'.format(context.author.mention,
-                                                                                exception.retry_after))
+            await context.send(f'{context.author.mention}, That command is on cooldown! Try again in {exception.retry_after:.2f}s!')
         elif isinstance(exception, commands.MaxConcurrencyReached):
             types = {discord.ext.commands.BucketType.default: "`Global`",
                      discord.ext.commands.BucketType.guild: "`Guild`",
@@ -112,13 +106,12 @@ class Dozer(commands.Bot):
                      discord.ext.commands.BucketType.category: "`Category`",
                      discord.ext.commands.BucketType.member: "`Member`", discord.ext.commands.BucketType.user: "`User`"}
             await context.send(
-                '{}, That command has exceeded the max {} concurrency limit of `{}` instance! Please try again later.'.format(
-                    context.author.mention, types[exception.per], exception.number))
+                f'{context.author.mention}, That command has exceeded the max {types[exception.per]} concurrency limit of '
+                f'`{exception.number}` instance! Please try again later.')
         elif isinstance(exception, (commands.CommandNotFound, InvalidContext)):
             pass  # Silent ignore
         else:
-            await context.send(
-                '```\n%s\n```' % ''.join(traceback.format_exception_only(type(exception), exception)).strip())
+            await context.send('```\n' + ''.join(traceback.format_exception_only(type(exception), exception)).strip() + '\n```')
             if isinstance(context.channel, discord.TextChannel):
                 logger.error('Error in command <%d> (%d.name!r(%d.id) %d(%d.id) %d(%d.id) %d)',
                              context.command, context.guild, context.guild, context.channel, context.channel,
@@ -131,7 +124,7 @@ class Dozer(commands.Bot):
 
     async def on_error(self, event_method, *args, **kwargs):
         """Don't ignore the error, causing Sentry to capture it."""
-        print('Ignoring exception in {}'.format(event_method), file=sys.stderr)
+        print(f'Ignoring exception in {event_method}', file=sys.stderr)
         traceback.print_exc()
         capture_exception()
 
@@ -142,7 +135,7 @@ class Dozer(commands.Bot):
         type_msg = ' '.join(map(str.lower, type_words))
 
         if err.args:
-            return '%s: %s' % (type_msg, utils.clean(ctx, err.args[0]))
+            return f'{type_msg}: {utils.clean(ctx, err.args[0])}'
         else:
             return type_msg
 

--- a/dozer/cogs/actionlogs.py
+++ b/dozer/cogs/actionlogs.py
@@ -72,7 +72,7 @@ class Actionlog(Cog):
                 embed = discord.Embed(color=0xFF0000)
                 embed.set_author(name='Member Left', icon_url=member.display_avatar.replace(format='png', size=32))
                 embed.description = format_join_leave(config[0].leave_message, member)
-                embed.set_footer(text="{} | {} members".format(member.guild.name, member.guild.member_count))
+                embed.set_footer(text=f"{member.guild.name} | {member.guild.member_count} members")
                 try:
                     await channel.send(embed=embed)
                 except discord.Forbidden:

--- a/dozer/cogs/development.py
+++ b/dozer/cogs/development.py
@@ -31,9 +31,9 @@ class Development(Cog):
     async def reload(self, ctx: DozerContext, cog: str):
         """Reloads a cog."""
         extension = 'dozer.cogs.' + cog
-        msg = await ctx.send('Reloading extension %s' % extension)
+        msg = await ctx.send(f'Reloading extension {extension}')
         await self.bot.reload_extension(extension)
-        await msg.edit(content='Reloaded extension %s' % extension)
+        await msg.edit(content=f'Reloaded extension {extension}')
 
     reload.example_usage = """
     `{prefix}reload development` - reloads the development cog
@@ -78,7 +78,7 @@ class Development(Cog):
         logger.info("-" * 32)
 
         e = discord.Embed(type='rich')
-        e.add_field(name='Code', value='```py\n%s\n```' % code, inline=False)
+        e.add_field(name='Code', value=f'```py\n{code}\n```', inline=False)
         try:
             locals_ = locals()
             load_function(code, self.eval_globals, locals_)
@@ -86,11 +86,18 @@ class Development(Cog):
 
             e.title = 'Python Evaluation - Success'
             e.color = 0x00FF00
-            e.add_field(name='Output', value='```\n%s (%s)\n```' % (repr(ret), type(ret).__name__), inline=False)
+            retr_str = f'{ret!r} ({type(ret).__name__})'
+            e.add_field(name='Output', value=f'```\n{retr_str if len(retr_str) < 1010 else retr_str[:1010] + "..."}\n```', inline=False)
         except Exception as err:
             e.title = 'Python Evaluation - Error'
             e.color = 0xFF0000
-            e.add_field(name='Error', value='```\n%s\n```' % repr(err))
+            retr_str = repr(err)
+            e.add_field(name='Error', value=f'```\n{retr_str if len(retr_str) < 1010 else retr_str[:1010] + "..."}\n```')
+        logger.info("Evaluation output:")
+        logger.info("-" * 32)
+        for line in retr_str.splitlines():
+            logger.info(line)
+        logger.info("-" * 32)
         await ctx.send('', embed=e)
 
     evaluate.example_usage = """

--- a/dozer/cogs/filter.py
+++ b/dozer/cogs/filter.py
@@ -129,9 +129,8 @@ class Filter(Cog):
         results = await WordFilter.get_by(guild_id=ctx.guild.id, enabled=True)
 
         if not results:
-            embed = discord.Embed(title="Filters for {}".format(ctx.guild.name))
-            embed.description = "No filters found for this guild! Add one using `{}filter add <regex> [name]`".format(
-                ctx.prefix)
+            embed = discord.Embed(title=f"Filters for {ctx.guild.name}")
+            embed.description = f"No filters found for this guild! Add one using `{ctx.prefix}filter add <regex> [name]`"
             embed.color = discord.Color.red()
             await ctx.send(embed=embed)
             return
@@ -143,7 +142,7 @@ class Filter(Cog):
         filter_text = '\n'.join(map(fmt.format, results))
 
         embed = discord.Embed()
-        embed.title = "Filters for {}".format(ctx.guild.name)
+        embed.title = f"Filters for {ctx.guild.name}"
         embed.add_field(name="Filters", value=filter_text)
         embed.color = discord.Color.dark_orange()
         await self.check_dm_filter(ctx, embed)
@@ -169,14 +168,14 @@ class Filter(Cog):
         try:
             re.compile(pattern)
         except re.error as err:
-            await ctx.send("Invalid RegEx! ```{}```".format(err.msg))
+            await ctx.send(f"Invalid RegEx! ```{err.msg}```")
             return
         new_filter = WordFilter(guild_id=ctx.guild.id, pattern=pattern, friendly_name=friendly_name or pattern)
         await new_filter.update_or_add()
         embed = discord.Embed()
         embed.title = "Filter added!"
-        embed.description = "A new filter with the name `{}` was added.".format(friendly_name or pattern)
-        embed.add_field(name="Pattern", value="`{}`".format(pattern))
+        embed.description = f"A new filter with the name `{friendly_name or pattern}` was added."
+        embed.add_field(name="Pattern", value=f"`{pattern}`")
         await ctx.send(embed=embed)
         await self.load_filters(ctx.guild.id)
 
@@ -190,7 +189,7 @@ class Filter(Cog):
         try:
             re.compile(pattern)
         except re.error as err:
-            await ctx.send("Invalid RegEx! ```{}```".format(err.msg))
+            await ctx.send(f"Invalid RegEx! ```{err.msg}```")
             return
         results = await WordFilter.get_by(guild_id=ctx.guild.id)
         found = False
@@ -210,8 +209,8 @@ class Filter(Cog):
         result.pattern = pattern
         await result.update_or_add()
         await self.load_filters(ctx.guild.id)
-        embed = discord.Embed(title="Updated filter {}".format(result.friendly_name or result.pattern))
-        embed.description = "Filter ID {} has been updated.".format(result.filter_id)
+        embed = discord.Embed(title=f"Updated filter {result.friendly_name or result.pattern}")
+        embed.description = f"Filter ID {result.filter_id} has been updated."
         embed.add_field(name="Old Pattern", value=old_pattern)
         embed.add_field(name="New Pattern", value=pattern)
         if enabled_change:
@@ -229,7 +228,7 @@ class Filter(Cog):
         """Remove a pattern from the filter list."""
         result = await WordFilter.get_by(filter_id=filter_id)
         if len(result) == 0:
-            await ctx.send("Filter ID {} not found!".format(filter_id))
+            await ctx.send(f"Filter ID {filter_id} not found!")
             return
         else:
             result = result[0]
@@ -238,7 +237,7 @@ class Filter(Cog):
             return
         result.enabled = False
         await result.update_or_add()
-        await ctx.send("Filter with name `{}` deleted.".format(result.friendly_name))
+        await ctx.send(f"Filter with name `{result.friendly_name}` deleted.")
         await self.load_filters(ctx.guild.id)
 
     remove.example_usage = "`{prefix}filter remove 7` - Disables filter with ID 7"
@@ -261,8 +260,7 @@ class Filter(Cog):
         await result.update_or_add()
         self.word_filter_setting.invalidate_entry(guild_id=ctx.guild.id, setting_type="dm")
         await ctx.send(
-            "The DM setting for this guild has been changed from {} to {}.".format(before_setting == "1",
-                                                                                   result.value == "1"))
+            f"The DM setting for this guild has been changed from {before_setting == '1'} to {result.value == '1'}.")
 
     dm_config.example_usage = "`{prefix}filter dm_config True` - Makes all messages containining filter lists to be " \
                               "sent through DMs "
@@ -276,7 +274,7 @@ class Filter(Cog):
         role_names = (role.name for role in role_objects if role is not None)
         roles_text = "\n".join(role_names)
         embed = discord.Embed()
-        embed.title = "Whitelisted roles for {}".format(ctx.guild.name)
+        embed.title = f"Whitelisted roles for {ctx.guild.name}"
         embed.description = "Anybody with any of the roles below will not have their messages filtered."
         embed.add_field(name="Roles", value=roles_text or "No roles")
         await ctx.send(embed=embed)
@@ -301,7 +299,7 @@ class Filter(Cog):
         whitelist_entry = WordFilterRoleWhitelist(role_id=role.id, guild_id=ctx.guild.id)
         await whitelist_entry.update_or_add()
         self.word_filter_role_whitelist.invalidate_entry(guild_id=ctx.guild.id)
-        await ctx.send("Whitelisted `{}` for this guild.".format(role.name))
+        await ctx.send(f"Whitelisted `{role.name}` for this guild.")
 
     whitelist_add.example_usage = "`{prefix}filter whitelist add Moderators` - Makes it so that Moderators will not be caught by the filter."
 
@@ -316,7 +314,7 @@ class Filter(Cog):
             return
         await WordFilterRoleWhitelist.delete(role_id=role.id)
         self.word_filter_role_whitelist.invalidate_entry(guild_id=ctx.guild.id)
-        await ctx.send("The role `{}` is no longer whitelisted.".format(role.name))
+        await ctx.send(f"The role `{role.name}` is no longer whitelisted.")
 
     whitelist_remove.example_usage = "`{prefix}filter whitelist remove Admins` - Makes it so that Admins are caught by the filter again."
 

--- a/dozer/cogs/general.py
+++ b/dozer/cogs/general.py
@@ -7,7 +7,7 @@ from discord.utils import escape_markdown
 
 from dozer.context import DozerContext
 from ._utils import *
-from ..utils import oauth_url
+from ..utils import oauth_url, clean
 
 blurple = discord.Color.blurple()
 
@@ -21,11 +21,11 @@ class General(Cog):
         if ctx.guild is None:
             location = 'DMs'
         else:
-            location = 'the **%s** server' % ctx.guild.name
-        response = await ctx.send('Pong! We\'re in %s.' % location)
+            location = f'the **{clean(ctx.guild.name)}** server'
+        response = await ctx.send(f'Pong! We\'re in {location}.')
         delay = response.created_at - ctx.message.created_at
         await response.edit(
-            content=response.content + '\nTook %d ms to respond.' % (delay.seconds * 1000 + delay.microseconds // 1000))
+            content=response.content + f'\nTook {(delay.seconds * 1000 + delay.microseconds // 1000)} ms to respond.')
 
     ping.example_usage = """
     `{prefix}ping` - Calculate and display the bot's response time
@@ -74,7 +74,7 @@ class General(Cog):
         info.set_thumbnail(url=self.bot.user.avatar)
         info.add_field(name='About',
                        value="Dozer: A collaborative bot for FIRST Discord servers, developed by the FRC Discord Server Development Team")
-        info.add_field(name='About `{}{}`'.format(ctx.prefix, ctx.invoked_with), value=inspect.cleandoc("""
+        info.add_field(name=f'About `{ctx.prefix}{ctx.invoked_with}`', value=inspect.cleandoc("""
         This command can show info for all commands, a specific command, or a category of commands.
         Use `{0}{1} {1}` for more information.
         """.format(ctx.prefix, ctx.invoked_with)), inline=False)
@@ -92,14 +92,14 @@ class General(Cog):
 
     async def _help_command(self, ctx: DozerContext, command):
         """Gets the help message for one command."""
-        info = discord.Embed(title='Command: {}{} {}'.format(ctx.prefix, command.qualified_name, command.signature),
+        info = discord.Embed(title=f'Command: {ctx.prefix}{command.qualified_name} {command.signature}',
                              description=command.help or (
                                  None if command.example_usage else 'No information provided.'),
                              color=discord.Color.blue())
         usage = command.example_usage
         if usage:
             info.add_field(name='Usage', value=usage.format(prefix=ctx.prefix, name=ctx.invoked_with), inline=False)
-        info.set_footer(text='Dozer Help | {!r} command | Info'.format(command.qualified_name))
+        info.set_footer(text=f'Dozer Help | {command.qualified_name!r} command | Info')
         await self._show_help(ctx, info, 'Subcommands: {prefix}{name} {signature}', '', '{name!r} command',
                               command.commands if isinstance(command, Group) else set(),
                               name=command.qualified_name, signature=command.signature)
@@ -115,7 +115,7 @@ class General(Cog):
                          footer: str, commands, **format_args):
         """Creates and sends a template help message, with arguments filled in."""
         format_args['prefix'] = ctx.prefix
-        footer = 'Dozer Help | {} | Page {}'.format(footer, '{page_num} of {len_pages}')
+        footer = 'Dozer Help | {footer} | Page {page_cnt}'.format(footer=footer, page_cnt='{page_num} of {len_pages}')
         # Page info is inserted as a parameter so page_num and len_pages aren't evaluated now
 
         if commands:
@@ -141,7 +141,7 @@ class General(Cog):
                             ctx, command)
                     else:
                         embed_value = 'No information provided.'
-                    page.add_field(name='{}{} {}'.format(ctx.prefix, command.qualified_name, command.signature),
+                    page.add_field(name=f'{ctx.prefix}{command.qualified_name} {command.signature}',
                                    value=embed_value, inline=False)
                 page.set_footer(text=footer.format(**format_args))
                 pages.append(page)
@@ -194,7 +194,7 @@ class General(Cog):
         perms = 0
         for cmd in ctx.bot.walk_commands():
             perms |= cmd.required_permissions.value
-        await ctx.send('<{}>'.format(oauth_url(ctx.me.id, discord.Permissions(perms))))
+        await ctx.send(f'<{oauth_url(ctx.me.id, discord.Permissions(perms))}>')
 
     @command(aliases=["setprefix"])
     @guild_only()

--- a/dozer/cogs/info.py
+++ b/dozer/cogs/info.py
@@ -166,7 +166,7 @@ class Info(Cog):
 
         embed.add_field(name='Created on', value=f"<t:{int(guild.created_at.timestamp())}:f>")
         embed.add_field(name='Owner', value=guild.owner)
-        embed.add_field(name='Emoji', value="{} static, {} animated".format(static_emoji, animated_emoji))
+        embed.add_field(name='Emoji', value=f"{static_emoji} static, {animated_emoji} animated")
         embed.add_field(name='Roles', value=str(len(guild.roles) - 1))  # Remove @everyone
         embed.add_field(name='Channels', value=str(len(guild.channels)))
         embed.add_field(name='Nitro Boost Info', value=f'Level {ctx.guild.premium_tier}, '

--- a/dozer/cogs/levels.py
+++ b/dozer/cogs/levels.py
@@ -158,7 +158,7 @@ class Levels(Cog):
         """Check to see if a member is in the level cache and if not load from the database"""
         cached_member = self._xp_cache.get((guild_id, member_id))
         if cached_member is None:
-            logger.debug("Cache miss: guild_id=%d, user_id=%d", guild_id, member_id)
+            logger.debug(f"Cache miss: guild_id={guild_id}, user_id={member_id}")
             records = await MemberXP.get_by(guild_id=guild_id, user_id=member_id)
             if records:
                 logger.debug("Loading from database")
@@ -244,7 +244,7 @@ class Levels(Cog):
             logger.warning("Task syncing records was cancelled prematurely, restarting")
         else:
             # exc could be None if the task returns normally, but that would also be an error
-            logger.error("Task syncing records failed: %r", exc)
+            logger.error(f"Task syncing records failed: {exc!r}")
         finally:
             self.sync_task.start()
 

--- a/dozer/cogs/maintenance.py
+++ b/dozer/cogs/maintenance.py
@@ -24,10 +24,8 @@ class Maintenance(Cog):
     async def shutdown(self, ctx: DozerContext):
         """Force-stops the bot."""
         await ctx.send('Shutting down')
-        logger.info('Shutting down at request of {}#{} (in {}, #{})'.format(ctx.author.name,
-                                                                            ctx.author.discriminator,
-                                                                            ctx.guild.name,
-                                                                            ctx.channel.name))
+        logger.info(f'Shutting down at request of {ctx.author.name}#{ctx.author.discriminator} '
+                    f'(in {ctx.guild.name}, #{ctx.channel.name})')
         await self.bot.shutdown()
 
     shutdown.example_usage = """

--- a/dozer/cogs/moderation.py
+++ b/dozer/cogs/moderation.py
@@ -479,9 +479,8 @@ class Moderation(Cog):
             targets = {member_role}
         else:
             await ctx.send(
-                '{0.author.mention}, the members role has not been configured. This may not work as expected. Use '
-                '`{0.prefix}help memberconfig` to see how to set this up.'.format(
-                    ctx))
+                f'{ctx.author.mention}, the members role has not been configured. This may not work as expected. Use '
+                f'`{ctx.prefix}help memberconfig` to see how to set this up.')
             targets = set(sorted(ctx.guild.roles)[:ctx.author.top_role.position])
 
         to_restore = [(target, ctx.channel.overwrites_for(target)) for target in targets]
@@ -497,7 +496,7 @@ class Moderation(Cog):
             await ctx.channel.set_permissions(allow_target, overwrite=new_overwrite)
             to_restore.append((allow_target, overwrite))
 
-        e = discord.Embed(title='Timeout - {}s'.format(duration), description='This channel has been timed out.',
+        e = discord.Embed(title=f'Timeout - {duration}s', description='This channel has been timed out.',
                           color=discord.Color.blue())
         e.set_author(name=escape_markdown(ctx.author.display_name), icon_url=ctx.author.display_avatar.replace(format='png', size=32))
         msg = await ctx.send(embed=e)
@@ -847,10 +846,10 @@ class Moderation(Cog):
         await config.update_or_add()
 
         role_name = role.name
+        # this should be an embed or something else entirely
         await ctx.send(
-            "New Member Channel configured as: {channel}. Role configured as: {role}. Team numbers required: {"
-            "required}. Message: {message}".format(
-                channel=channel_mention.name, role=role_name, required=requireteam, message=message))
+            f"New Member Channel configured as: {channel_mention.name}. Role configured as: {role_name}. "
+            f"Team numbers required: {requireteam}. Message: {message}")
 
     nmconfig.example_usage = """
     `{prefix}nmconfig #new_members Member I have read the rules and regulations` - Configures the #new_members channel 
@@ -887,7 +886,7 @@ class Moderation(Cog):
             settings = settings[0]
             settings.member_role = member_role.id
         await settings.update_or_add()
-        await ctx.send('Member role set as `{}`.'.format(member_role.name))
+        await ctx.send(f'Member role set as `{member_role.name}`.')
 
     memberconfig.example_usage = """
     `{prefix}memberconfig Members` - set a role called "Members" as the member role

--- a/dozer/cogs/music.py
+++ b/dozer/cogs/music.py
@@ -52,7 +52,7 @@ class Music(commands.Cog):
         elif isinstance(tracks, lavaplayer.PlayList):
             msg = await ctx.send("Playlist found, Adding to queue, Please wait...")
             await self.lavalink.add_to_queue(ctx.guild.id, tracks.tracks, ctx.author.id)
-            await msg.edit(content="Added to queue, tracks: {}, name: {}".format(len(tracks.tracks), tracks.name))
+            await msg.edit(content=f"Added to queue, tracks: {len(tracks.tracks)}, name: {tracks.name}")
             return
         await self.lavalink.wait_for_connection(ctx.guild.id)
         await self.lavalink.play(ctx.guild.id, tracks[0], ctx.author.id)

--- a/dozer/cogs/news.py
+++ b/dozer/cogs/news.py
@@ -352,7 +352,7 @@ class News(Cog):
             results = await NewsSubscription.get_by(guild_id=ctx.guild.id)
 
         if not results:
-            embed = discord.Embed(title="News Subscriptions for {}".format(ctx.guild.name))
+            embed = discord.Embed(title=f"News Subscriptions for {ctx.guild.name}")
             embed.description = f"No news subscriptions found for this guild! Add one using `{self.bot.command_prefix}" \
                                 f"news add <channel> <source>`"
             embed.colour = discord.Color.red()
@@ -372,7 +372,7 @@ class News(Cog):
                 channels[channel] = [result]
 
         embed = discord.Embed()
-        embed.title = "News Subscriptions for {}".format(ctx.guild.name)
+        embed.title = f"News Subscriptions for {ctx.guild.name}"
         embed.colour = discord.Color.dark_orange()
         for found_channel, lst in channels.items():
             subs = ""

--- a/dozer/cogs/polls.py
+++ b/dozer/cogs/polls.py
@@ -53,7 +53,7 @@ class Polls(Cog):
         # Create embed response
         description = []
         for x, option in enumerate(options):
-            description += '{}  {}\n\n'.format(reactions[x], option)
+            description += f'{reactions[x]}  {option}\n\n'
         embed = discord.Embed(
             title=title,
             description=''.join(description),

--- a/dozer/cogs/roles.py
+++ b/dozer/cogs/roles.py
@@ -169,7 +169,7 @@ class Roles(Cog):
         if not missing and not cant_give:
             return
 
-        e = discord.Embed(title='Welcome back to the {} server, {}!'.format(member.guild.name, member),
+        e = discord.Embed(title=f'Welcome back to the {member.guild.name} server, {member}!',
                           color=discord.Color.blue())
         if missing:
             e.add_field(name='I couldn\'t restore these roles, as they don\'t exist.', value='\n'.join(sorted(missing)))
@@ -237,15 +237,15 @@ class Roles(Cog):
         e = discord.Embed(color=discord.Color.blue())
         if given:
             given_names = sorted((role.name for role in given), key=str.casefold)
-            e.add_field(name='Gave you {} role(s)!'.format(len(given)), value='\n'.join(given_names), inline=False)
+            e.add_field(name=f'Gave you {len(given)} role(s)!', value='\n'.join(given_names), inline=False)
         if already_have:
             already_have_names = sorted((role.name for role in already_have), key=str.casefold)
-            e.add_field(name='You already have {} role(s)!'.format(len(already_have)),
+            e.add_field(name=f'You already have {len(already_have)} role(s)!',
                         value='\n'.join(already_have_names), inline=False)
         extra = len(norm_names) - len(valid)
         if extra > 0:
-            e.add_field(name='{} role(s) could not be found!'.format(extra),
-                        value='Use `{0.prefix}{0.invoked_with} list` to find valid giveable roles!'.format(ctx),
+            e.add_field(name=f'{extra} role(s) could not be found!',
+                        value=f'Use `{ctx.prefix}{ctx.invoked_with} list` to find valid giveable roles!',
                         inline=False)
         msg = await ctx.send(embed=e)
         try:
@@ -289,7 +289,7 @@ class Roles(Cog):
     async def purge(self, ctx: DozerContext):
         """Force a purge of giveme roles that no longer exist in the guild"""
         counter = await self.ctx_purge(ctx)
-        await ctx.send("Purged {} role(s)".format(counter))
+        await ctx.send(f"Purged {counter} role(s)")
 
     @giveme.command()
     @bot_has_permissions(manage_roles=True)
@@ -306,14 +306,13 @@ class Roles(Cog):
         candidates = [role for role in ctx.guild.roles if self.normalize(role.name) == norm_name]
 
         if not candidates:
-            role = await ctx.guild.create_role(name=name, reason='Giveable role created by {}'.format(ctx.author))
+            role = await ctx.guild.create_role(name=name, reason=f'Giveable role created by {ctx.author}')
         elif len(candidates) == 1:
             role = candidates[0]
         else:
-            raise BadArgument('{} roles with that name exist!'.format(len(candidates)))
+            raise BadArgument(f'{len(candidates)} roles with that name exist!')
         await GiveableRole.from_role(role).update_or_add()
-        await ctx.send(
-            'Role "{0}" added! Use `{1}{2} {0}` to get it!'.format(role.name, ctx.prefix, ctx.command.parent))
+        await ctx.send(f'Role "{role.name}" added! Use `{ctx.prefix}{ctx.command.parent} {role.name}` to get it!')
 
     add.example_usage = """
     `{prefix}giveme add Java` - creates or finds a role named "Java" and makes it giveable
@@ -331,11 +330,10 @@ class Roles(Cog):
         norm_name = self.normalize(name)
         settings = await GiveableRole.get_by(guild_id=ctx.guild.id, norm_name=norm_name)
         if not settings:
-            role = await ctx.guild.create_role(name=name, reason='Giveable role created by {}'.format(ctx.author))
+            role = await ctx.guild.create_role(name=name, reason=f'Giveable role created by {ctx.author}')
             settings = GiveableRole.from_role(role)
             await settings.update_or_add()
-            await ctx.send(
-                'Role "{0}" created! Use `{1}{2} {0}` to get it!'.format(role.name, ctx.prefix, ctx.command.parent))
+            await ctx.send(f'Role "{role.name}" created! Use `{ctx.prefix}{ctx.command.parent} {role.name}` to get it!')
 
         else:
             raise BadArgument('that role already exists and is giveable!')
@@ -365,15 +363,15 @@ class Roles(Cog):
         e = discord.Embed(color=discord.Color.blue())
         if removed:
             removed_names = sorted((role.name for role in removed), key=str.casefold)
-            e.add_field(name='Removed {} role(s)!'.format(len(removed)), value='\n'.join(removed_names), inline=False)
+            e.add_field(name=f'Removed {len(removed)} role(s)!', value='\n'.join(removed_names), inline=False)
         if dont_have:
             dont_have_names = sorted((role.name for role in dont_have), key=str.casefold)
-            e.add_field(name='You didn\'t have {} role(s)!'.format(len(dont_have)), value='\n'.join(dont_have_names),
+            e.add_field(name=f'You didn\'t have {len(dont_have)} role(s)!', value='\n'.join(dont_have_names),
                         inline=False)
         extra = len(norm_names) - len(valid)
         if extra > 0:
-            e.add_field(name='{} role(s) could not be found!'.format(extra),
-                        value='Use `{0.prefix}{0.invoked_with} list` to find valid giveable roles!'.format(ctx),
+            e.add_field(name=f'{extra} role(s) could not be found!',
+                        value=f'Use `{ctx.prefix}{ctx.invoked_with} list` to find valid giveable roles!',
                         inline=False)
         msg = await ctx.send(embed=e)
         try:
@@ -426,8 +424,8 @@ class Roles(Cog):
         else:
             role = ctx.guild.get_role(valid_roles[0].role_id)
             await GiveableRole.delete(guild_id=ctx.guild.id, norm_name=valid_roles[0].norm_name)
-            await role.delete(reason='Giveable role deleted by {}'.format(ctx.author))
-            await ctx.send('Role "{0}" deleted!'.format(role))
+            await role.delete(reason=f'Giveable role deleted by {ctx.author}')
+            await ctx.send(f'Role "{role}" deleted!')
 
     delete.example_usage = """
     `{prefix}giveme delete Java` - deletes the role called "Java" if it's giveable (automatically removes it from all members)
@@ -473,7 +471,7 @@ class Roles(Cog):
             raise BadArgument('multiple giveable roles with that name exist!')
         else:
             await GiveableRole.delete(guild_id=ctx.guild.id, norm_name=valid_roles[0].norm_name)
-            await ctx.send('Role "{0}" deleted from list!'.format(name))
+            await ctx.send(f'Role "{name}" deleted from list!')
 
     delete.example_usage = """
     `{prefix}giveme removefromlist Java` - removes the role "Java" from the list of giveable roles but does not remove it from the server or members who have it 
@@ -505,7 +503,7 @@ class Roles(Cog):
         await ent.update_or_add()
         self.bot.loop.create_task(self.removal_timer(ent))
         e = discord.Embed(color=blurple)
-        e.add_field(name='Success!', value='I gave {} to {}, for {}!'.format(role.mention, member.mention, length))
+        e.add_field(name='Success!', value=f'Gave {role.mention} to {member.mention} for {length}!')
         e.set_footer(text='Triggered by ' + escape_markdown(ctx.author.display_name))
         await ctx.send(embed=e)
 
@@ -522,7 +520,7 @@ class Roles(Cog):
             raise BadArgument('Cannot give roles higher than your top role!')
         await member.add_roles(role)
         e = discord.Embed(color=blurple)
-        e.add_field(name='Success!', value='I gave {} to {}!'.format(role, member))
+        e.add_field(name='Success!', value=f'Gave {role} to {member}!')
         e.set_footer(text='Triggered by ' + escape_markdown(ctx.author.display_name))
         await ctx.send(embed=e)
 
@@ -539,7 +537,7 @@ class Roles(Cog):
             raise BadArgument('Cannot take roles higher than your top role!')
         await member.remove_roles(role)
         e = discord.Embed(color=blurple)
-        e.add_field(name='Success!', value='I took {} from {}!'.format(role, member))
+        e.add_field(name='Success!', value=f'Took {role} from {member}!')
         e.set_footer(text='Triggered by ' + escape_markdown(ctx.author.display_name))
         await ctx.send(embed=e)
 

--- a/dozer/cogs/tba.py
+++ b/dozer/cogs/tba.py
@@ -56,7 +56,7 @@ class TBA(Cog):
         except aiotba.http.AioTBAError:
             raise BadArgument(f"Couldn't find data for team {team_num}.")
         if team_data.city is None:
-            raise BadArgument("team {} exists, but has no information!".format(team_num))
+            raise BadArgument(f"team {team_num} exists, but has no information!")
 
         try:
             team_district_data = await self.session.team_districts(team_num)
@@ -65,9 +65,9 @@ class TBA(Cog):
         except aiotba.http.AioTBAError:
             team_district_data = None
         e = discord.Embed(color=self.col,
-                          title='FIRST® Robotics Competition Team {}'.format(team_num),
-                          url='https://www.thebluealliance.com/team/{}'.format(team_num))
-        e.set_thumbnail(url='https://frcavatars.herokuapp.com/get_image?team={}'.format(team_num))
+                          title=f'FIRST® Robotics Competition Team {team_num}',
+                          url=f'https://www.thebluealliance.com/team/{team_num}')
+        e.set_thumbnail(url=f'https://frcavatars.herokuapp.com/get_image?team={team_num}')
         e.add_field(name='Name', value=team_data.nickname)
         e.add_field(name='Rookie Year', value=team_data.rookie_year)
         e.add_field(name='Location',
@@ -80,7 +80,7 @@ class TBA(Cog):
             e.add_field(name='Championship', value=team_data.home_championship[max(team_data.home_championship.keys())])
         except AttributeError:
             e.add_field(name='Championship', value="Unknown")
-        e.set_footer(text='Triggered by {}'.format(ctx.author.display_name))
+        e.set_footer(text=f'Triggered by {ctx.author.display_name}')
         await ctx.send(embed=e)
 
     team.example_usage = """
@@ -152,7 +152,7 @@ class TBA(Cog):
                 }.get(media.type, (None, None, None))
                 media.details['foreign_key'] = media.foreign_key
                 if name is not None:
-                    page = discord.Embed(title="{}{}".format(base, name), url=url.format(**media.details))
+                    page = discord.Embed(title=f"{base}{name}", url=url.format(**media.details))
                     page.set_image(url=img_url.format(**media.details))
                     pages.append(page)
 
@@ -162,7 +162,7 @@ class TBA(Cog):
                 await ctx.send(f"No media for team {team_num} found in {year}!")
 
         except aiotba.http.AioTBAError:
-            raise BadArgument("Couldn't find data for team {}".format(team_num))
+            raise BadArgument(f"Couldn't find data for team {team_num}")
 
     media.example_usage = """
     `{prefix}tba media 971 2016` - show available media from team 971 Spartan Robotics in 2016
@@ -178,7 +178,7 @@ class TBA(Cog):
                 events_data = await self.session.team_events(team_num, year=year)
                 event_key_map = {event.key: event for event in events_data}
             except aiotba.http.AioTBAError:
-                raise BadArgument("Couldn't find data for team {}".format(team_num))
+                raise BadArgument(f"Couldn't find data for team {team_num}")
 
             pages = []
         for award_year, awards in itertools.groupby(awards_data, lambda a: a.year):
@@ -210,17 +210,17 @@ class TBA(Cog):
         try:
             team_data = await self.session.team(team_num)
             e = discord.Embed(color=self.col)
-            e.set_author(name='FIRST® Robotics Competition Team {}'.format(team_num),
-                         url='https://www.thebluealliance.com/team/{}'.format(team_num),
-                         icon_url='https://frcavatars.herokuapp.com/get_image?team={}'.format(team_num))
-            e.add_field(name='Raw Data', value="```py\n {}```".format(pformat(team_data.__dict__)))
-            e.set_footer(text='Triggered by {}'.format(escape_markdown(ctx.author.display_name)))
+            e.set_author(name=f'FIRST® Robotics Competition Team {team_num}',
+                         url=f'https://www.thebluealliance.com/team/{team_num}',
+                         icon_url=f'https://frcavatars.herokuapp.com/get_image?team={team_num}')
+            e.add_field(name='Raw Data', value=f"```py\n {pformat(team_data.__dict__)}```")
+            e.set_footer(text=f'Triggered by {ctx.author.display_name}')
             await ctx.send(embed=e)
         except aiotba.http.AioTBAError:
-            raise BadArgument('Team {} does not exist.'.format(team_num))
+            raise BadArgument(f'Team {team_num} does not exist.')
 
     raw.example_usage = """
-    `{prefix}tba raw 4150` - show raw information on team 4150, FRobotics
+    `{prefix}tba raw 1339` - show raw information on team 1339, AngelBotics
     """
 
     class TeamData:
@@ -238,11 +238,11 @@ class TBA(Cog):
             try:
                 td = await self.session.team(team_num)
             except aiotba.http.AioTBAError:
-                raise BadArgument('Team {} does not exist.'.format(team_num))
+                raise BadArgument(f'Team {team_num} does not exist.')
         elif team_program.lower() == "ftc":
-            res = json.loads(await self.bot.cogs['TOA'].parser.req("team/{}".format(team_num)))
+            res = json.loads(await self.bot.cogs['TOA'].parser.req(f"team/{team_num}"))
             if not res:
-                raise BadArgument('Team {} does not exist.'.format(team_num))
+                raise BadArgument(f'Team {team_num} does not exist.')
             td_dict = res[0]
             td = self.TeamData()
             td.__dict__.update(td_dict)
@@ -253,8 +253,7 @@ class TBA(Cog):
         if td.country == "USA":
             td.country = "United States of America"
             units = 'u'
-        url = "https://wttr.in/{}".format(
-            urlquote("{}+{}+{}_0_{}.png".format(td.city, td.state_prov, td.country, units)))
+        url = "https://wttr.in/" + urlquote(f"{td.city}+{td.state_prov}+{td.country}_0_{units}.png")
 
         async with ctx.typing(), self.http_session.get(url) as resp:
             image_data = io.BytesIO(await resp.read())
@@ -280,46 +279,42 @@ class TBA(Cog):
             try:
                 team_data = await self.session.team(team_num)
             except aiotba.http.AioTBAError:
-                raise BadArgument('Team {} does not exist.'.format(team_num))
+                raise BadArgument(f'Team {team_num} does not exist.')
             if team_data.city is None:
-                raise BadArgument("team {} exists, but does not have sufficient information!".format(team_num))
+                raise BadArgument(f"team {team_num} exists, but does not have sufficient information!")
 
         elif team_program.lower() == "ftc":
-            res = json.loads(await self.bot.cogs['TOA'].parser.req("team/{}".format(str(team_num))))
+            res = json.loads(await self.bot.cogs['TOA'].parser.req(f"team/{team_num}"))
             if not res:
-                raise BadArgument('Team {} does not exist.'.format(team_num))
+                raise BadArgument(f'Team {team_num} does not exist.')
             team_data_dict = res[0]
             team_data = self.TeamData()
             team_data.__dict__.update(team_data_dict)
         else:
             raise BadArgument('`team_program` should be one of [`frc`, `ftc`]')
 
-        location = '{0.city}, {0.state_prov} {0.country}'.format(team_data)
+        location = f'{team_data.city}, {team_data.state_prov} {team_data.country}'
         gmaps = googlemaps.Client(key=self.gmaps_key)
         geolocator = Nominatim(user_agent="Dozer Discord Bot")
         geolocation = geolocator.geocode(location)
 
         if self.gmaps_key and not self.bot.config['tz_url']:
-            timezone = gmaps.timezone(location="{}, {}".format(geolocation.latitude, geolocation.longitude),
-                                      language="json")
+            timezone = gmaps.timezone(location=f"{geolocation.latitude}, {geolocation.longitude}", language="json")
             utc_offset = float(timezone["rawOffset"]) / 3600
             if timezone["dstOffset"] == 3600:
                 utc_offset += 1
             tzname = timezone["timeZoneName"]
         else:
             async with async_timeout.timeout(5), self.bot.http_session.get(urljoin(base=self.bot.config['tz_url'],
-                                                                                   url="{}/{}".format(
-                                                                                       geolocation.latitude,
-                                                                                       geolocation.longitude))) as r:
+                                                                                   url=f"{geolocation.latitude}/{geolocation.longitude}")) as r:
                 r.raise_for_status()
                 data = await r.json()
                 utc_offset = data["utc_offset"]
-                tzname = '`{}`'.format(data["tz"])
+                tzname = f'`{data["tz"]}`'
 
         current_time = datetime.datetime.utcnow() + datetime.timedelta(hours=utc_offset)
 
-        await ctx.send("Timezone: {} UTC{}\n{}".format(tzname, utc_offset,
-                                                       current_time.strftime("Current Time: %I:%M:%S %p (%H:%M:%S)")))
+        await ctx.send(f'Timezone: {tzname} UTC{utc_offset}\n{current_time.strftime("Current Time: %I:%M:%S %p (%H:%M:%S)")}')
 
     timezone.example_usage = """
     `{prefix}timezone frc 5052` - show the local time of FRC team 5052, The RoboLobos

--- a/dozer/cogs/teams.py
+++ b/dozer/cogs/teams.py
@@ -39,7 +39,7 @@ class Teams(Cog):
         results = await TeamNumbers.get_by(user_id=ctx.author.id, team_type=team_type, team_number=team_number)
         if len(results) != 0:
             await TeamNumbers.delete(user_id=ctx.author.id, team_number=team_number, team_type=team_type)
-            await ctx.send("Removed association with {} team {}".format(team_type, team_number))
+            await ctx.send(f"Removed association with {team_type} team {team_number}")
         else:
             await ctx.send("Couldn't find any associations with that team!")
 
@@ -58,10 +58,10 @@ class Teams(Cog):
             raise BadArgument("Couldn't find any team associations for that user!")
         else:
             e = discord.Embed(type='rich')
-            e.title = 'Teams for {}'.format(escape_markdown(user.display_name))
+            e.title = f'Teams for {escape_markdown(user.display_name)}'
             e.description = "Teams: \n"
             for i in teams:
-                e.description = "{} {} Team {} \n".format(e.description, i.team_type.upper(), i.team_number)
+                e.description = f"{e.description} {i.team_type.upper()} Team {i.team_number} \n"
             await ctx.send(embed=e)
 
     teamsfor.example_usage = """
@@ -92,13 +92,13 @@ class Teams(Cog):
         embeds = []
         for team in teams:
             e = discord.Embed(type='rich')
-            e.title = 'Members going to {}'.format(event_key)
+            e.title = f'Members going to {event_key}'
             members = await TeamNumbers.get_by(team_type=event_type.lower(), team_number=team)
             memstr = ""
             for member in members:
                 mem = ctx.guild.get_member(member.user_id)
                 if mem is not None:
-                    newmemstr = "{} {} \n".format(escape_markdown(mem.display_name), mem.mention)
+                    newmemstr = f"{escape_markdown(mem.display_name)} {mem.mention} \n"
                     if len(newmemstr + memstr) > 1023:
                         e.add_field(name=f"Team {team}", value=memstr)
                         memstr = ""
@@ -108,7 +108,7 @@ class Teams(Cog):
                 if len(e.fields) == 25:
                     embeds.append(e)
                     e = discord.Embed(type='rich')
-                    e.title = 'Members going to {}'.format(event_key)
+                    e.title = f'Members going to {event_key}'
                 e.add_field(name=f"Team {team}", value=memstr)
                 embeds.append(e)
         if not found_mems:
@@ -136,19 +136,19 @@ class Teams(Cog):
             await ctx.send("Nobody on that team found!")
         else:
             e = discord.Embed(type='rich')
-            e.title = 'Users on team {}'.format(team_number)
+            e.title = f'Users on team {team_number}'
             e.description = "Users: \n"
             extra_mems = ""
             for i in users:
                 user = ctx.guild.get_member(i.user_id)
                 if user is not None:
-                    memstr = "{} {} \n".format(escape_markdown(user.display_name), user.mention)
+                    memstr = f"{escape_markdown(user.display_name)} {user.mention} \n"
                     if len(e.description + memstr) > 2047:
                         extra_mems += memstr
                     else:
                         e.description = e.description + memstr
             if len(extra_mems) != 0:
-                e.add_field(name="Users on team {}".format(team_number), value=extra_mems)
+                e.add_field(name=f"Users on team {team_number}", value=extra_mems)
             await ctx.send(embed=e)
 
     onteam.example_usage = """
@@ -196,7 +196,7 @@ class Teams(Cog):
         if member.guild.me.guild_permissions.manage_nicknames and enabled:
             query = await TeamNumbers.get_by(user_id=member.id)
             if len(query) == 1:
-                nick = "{} {}{}".format(member.display_name, query[0].team_type, query[0].team_number)
+                nick = f"{member.display_name} {query[0].team_type}{query[0].team_number}"
                 if len(nick) <= 32:
                     await member.edit(nick=nick)
 

--- a/dozer/cogs/toa.py
+++ b/dozer/cogs/toa.py
@@ -87,15 +87,15 @@ class TOA(Cog):
         team_data = res[0]
 
         e = discord.Embed(color=embed_color)
-        e.set_author(name='FIRST® Tech Challenge Team {}'.format(team_num),
-                     url='https://theorangealliance.org/teams/{}'.format(team_num),
+        e.set_author(name=f'FIRST® Tech Challenge Team {team_num}',
+                     url=f'https://theorangealliance.org/teams/{team_num}',
                      icon_url='https://theorangealliance.org/assets/imgs/favicon.png?v=1')
         e.add_field(name='Name', value=team_data['team_name_short'])
         e.add_field(name='Rookie Year', value=team_data['rookie_year'])
         e.add_field(name='Location',
                     value=', '.join((team_data['city'], team_data['state_prov'], team_data['country'])))
         e.add_field(name='Website', value=team_data['website'] or 'n/a')
-        e.add_field(name='Team Info Page', value='https://theorangealliance.org/teams/{}'.format(team_data['team_key']))
+        e.add_field(name='Team Info Page', value=f'https://theorangealliance.org/teams/{team_data["team_key"]}')
         e.set_footer(text='Triggered by ' + escape_markdown(ctx.author.display_name))
         await ctx.send('', embed=e)
 

--- a/dozer/cogs/voice.py
+++ b/dozer/cogs/voice.py
@@ -76,11 +76,9 @@ class Voice(Cog):
             config = await AutoPTT.get_by(channel_id=voice_channel.id)
             if len(config) != 0:
                 await AutoPTT.delete(channel_id=config[0].channel_id)
-                e.add_field(name='Success!', value='AutoPTT has been disabled for voice channel "**{}**"'
-                            .format(voice_channel))
+                e.add_field(name='Success!', value=f'AutoPTT has been disabled for voice channel "**{voice_channel}**"')
             else:
-                e.add_field(name='Error', value='AutoPTT has not been configured for voice channel "**{}**"'
-                            .format(voice_channel))
+                e.add_field(name='Error', value=f'AutoPTT has not been configured for voice channel "**{voice_channel}**"')
         else:
             ent = AutoPTT(
                 channel_id=voice_channel.id,
@@ -89,8 +87,7 @@ class Voice(Cog):
 
             await ent.update_or_add()
 
-            e.add_field(name='Success!', value='Voice Channel **{}**\'s PTT threshold set to {} members'
-                        .format(voice_channel, ptt_threshold))
+            e.add_field(name='Success!', value=f'Voice Channel **{voice_channel}**\'s PTT threshold set to {ptt_threshold} members')
 
         await ctx.send(embed=e)
 
@@ -114,8 +111,7 @@ class Voice(Cog):
         else:
             await Voicebinds(channel_id=voice_channel.id, role_id=role.id, guild_id=ctx.guild.id).update_or_add()
 
-        await ctx.send("Role `{role}` will now be given to users in voice channel `{voice_channel}`!".format(role=role,
-                                                                                                             voice_channel=voice_channel))
+        await ctx.send(f"Role `{role}` will now be given to users in voice channel `{voice_channel}`!")
 
     voicebind.example_usage = """
     `{prefix}voicebind "General #1" voice-general-1` - sets up Dozer to give users  `voice-general-1` when they join voice channel "General #1", which will be removed when they leave.
@@ -130,12 +126,9 @@ class Voice(Cog):
         if len(config) != 0:
             role = ctx.guild.get_role(config[0].role_id)
             await Voicebinds.delete(id=config[0].id)
-            await ctx.send(
-                "Role `{role}` will no longer be given to users in voice channel `{voice_channel}`!".format(
-                    role=role, voice_channel=voice_channel))
+            await ctx.send(f"Role `{role}` will no longer be given to users in voice channel `{voice_channel}`!")
         else:
-            await ctx.send("It appears that `{voice_channel}` is not associated with a role!".format(
-                voice_channel=voice_channel))
+            await ctx.send(f"It appears that `{voice_channel}` is not associated with a role!")
 
     voiceunbind.example_usage = """
     `{prefix}voiceunbind "General #1"` - Removes automatic role-giving for users in "General #1".
@@ -145,11 +138,11 @@ class Voice(Cog):
     @bot_has_permissions(manage_roles=True)
     async def voicebindlist(self, ctx: DozerContext):
         """Lists all the voice channel to role bindings for the current server"""
-        embed = discord.Embed(title="List of voice bindings for \"{}\"".format(ctx.guild), color=discord.Color.blue())
+        embed = discord.Embed(title=f"List of voice bindings for \"{ctx.guild}\"", color=discord.Color.blue())
         for config in await Voicebinds.get_by(guild_id=ctx.guild.id):
             channel = discord.utils.get(ctx.guild.voice_channels, id=config.channel_id)
             role = ctx.guild.get_role(config.role_id)
-            embed.add_field(name=channel, value="`{}`".format(role))
+            embed.add_field(name=channel, value=f"`{role}`")
         await ctx.send(embed=embed)
 
     voicebindlist.example_usage = """

--- a/dozer/utils.py
+++ b/dozer/utils.py
@@ -40,35 +40,35 @@ def clean_member_name(ctx, member_id):
     """Cleans a member's name from the message."""
     member = ctx.guild.get_member(member_id)
     if member is None:
-        return '<@\N{ZERO WIDTH SPACE}%d>' % member_id
+        return f'<@\N{ZERO WIDTH SPACE}{member_id:d}>'
     elif is_clean(ctx, member.display_name):
         return member.display_name
     elif is_clean(ctx, str(member)):
         return str(member)
     else:
-        return '<@\N{ZERO WIDTH SPACE}%d>' % member.id
+        return f'<@\N{ZERO WIDTH SPACE}{member.id:d}>'
 
 
 def clean_role_name(ctx, role_id):
     """Cleans role pings from messages."""
     role = discord.utils.get(ctx.guild.roles, id=role_id)  # Guild.get_role doesn't exist
     if role is None:
-        return '<@&\N{ZERO WIDTH SPACE}%d>' % role_id
+        return f'<@&\N{ZERO WIDTH SPACE}{role_id:d}>'
     elif is_clean(ctx, role.name):
         return '@' + role.name
     else:
-        return '<@&\N{ZERO WIDTH SPACE}%d>' % role.id
+        return f'<@&\N{ZERO WIDTH SPACE}{role.id:d}>'
 
 
 def clean_channel_name(ctx, channel_id):
     """Cleans channel mentions from messages."""
     channel = ctx.guild.get_channel(channel_id)
     if channel is None:
-        return '<#\N{ZERO WIDTH SPACE}%d>' % channel_id
+        return f'<#\N{ZERO WIDTH SPACE}{channel_id:d}>'
     elif is_clean(ctx, channel.name):
         return '#' + channel.name
     else:
-        return '<#\N{ZERO WIDTH SPACE}%d>' % channel.id
+        return f'<#\N{ZERO WIDTH SPACE}{channel.id:d}>'
 
 
 def pretty_concat(strings, single_suffix='', multi_suffix=''):
@@ -76,9 +76,9 @@ def pretty_concat(strings, single_suffix='', multi_suffix=''):
     if len(strings) == 1:
         return strings[0] + single_suffix
     elif len(strings) == 2:
-        return '{} and {}{}'.format(*strings, multi_suffix)
+        return f'{strings[0]} and {strings[1]}{multi_suffix}'
     else:
-        return '{}, and {}{}'.format(', '.join(strings[:-1]), strings[-1], multi_suffix)
+        return f'{", ".join(strings[:-1])}, and {strings[-1]}{multi_suffix}'
 
 
 def oauth_url(client_id, permissions=None, guild=None, redirect_uri=None):
@@ -102,7 +102,7 @@ def oauth_url(client_id, permissions=None, guild=None, redirect_uri=None):
     :class:`str`
         The OAuth2 URL for inviting the bot into guilds.
     """
-    url = 'https://discord.com/oauth2/authorize?client_id={}&scope=bot%20applications.commands'.format(client_id)
+    url = f'https://discord.com/oauth2/authorize?client_id={client_id}&scope=bot%20applications.commands'
     if permissions is not None:
         url = url + '&permissions=' + str(permissions.value)
     if guild is not None:


### PR DESCRIPTION
All unparameterized "{}".format() calls, along with the few %-formatting instances in the codebase have been replaced by f-strings or other more appropriate constructions.

A few other things have been tweaked:
 - %eval embeds that are too long are now truncated and are also logged to console
 - a logging call or two got fixed