### PR TITLE
Fix ping command

### DIFF
--- a/dozer/cogs/general.py
+++ b/dozer/cogs/general.py
@@ -21,7 +21,7 @@ class General(Cog):
         if ctx.guild is None:
             location = 'DMs'
         else:
-            location = f'the **{None, text=clean(ctx.guild.name)}** server'
+            location = f'the **{text=clean(None, ctx.guild.name)}** server'
         response = await ctx.send(f'Pong! We\'re in {location}.')
         delay = response.created_at - ctx.message.created_at
         await response.edit(

--- a/dozer/cogs/general.py
+++ b/dozer/cogs/general.py
@@ -21,7 +21,7 @@ class General(Cog):
         if ctx.guild is None:
             location = 'DMs'
         else:
-            location = f'the **{lean(None, text=cctx.guild.name)}** server'
+            location = f'the **{clean(None, text=ctx.guild.name)}** server'
         response = await ctx.send(f'Pong! We\'re in {location}.')
         delay = response.created_at - ctx.message.created_at
         await response.edit(

--- a/dozer/cogs/general.py
+++ b/dozer/cogs/general.py
@@ -21,7 +21,7 @@ class General(Cog):
         if ctx.guild is None:
             location = 'DMs'
         else:
-            location = f'the **{clean(ctx.guild.name)}** server'
+            location = f'the **{None, text=clean(ctx.guild.name)}** server'
         response = await ctx.send(f'Pong! We\'re in {location}.')
         delay = response.created_at - ctx.message.created_at
         await response.edit(

--- a/dozer/cogs/general.py
+++ b/dozer/cogs/general.py
@@ -21,7 +21,7 @@ class General(Cog):
         if ctx.guild is None:
             location = 'DMs'
         else:
-            location = f'the **{text=clean(None, ctx.guild.name)}** server'
+            location = f'the **{lean(None, text=cctx.guild.name)}** server'
         response = await ctx.send(f'Pong! We\'re in {location}.')
         delay = response.created_at - ctx.message.created_at
         await response.edit(


### PR DESCRIPTION
Passes None to the required positional-only argument ctx of the clean command, along with the text argument as a keyword. Tested on a self hosted instance, fixed the error it had previously. Could also be modified to pass the context of the ping command, though there's no reason to do that as the context is only used if text is None.

Previous error since I couldn't find any issue to reference:
The ping command previously would fail with the following error sent by the bot:
`discord.ext.commands.errors.CommandInvokeError: Command raised an exception: AttributeError: 'str' object has no attribute 'message'`