### PR TITLE
Updated info.py

### DIFF
--- a/dozer/cogs/info.py
+++ b/dozer/cogs/info.py
@@ -3,6 +3,8 @@ import math
 import typing
 from datetime import timezone, datetime, date
 from difflib import SequenceMatcher
+import time
+import re
 
 import discord
 import humanize
@@ -30,10 +32,7 @@ class Info(Cog):
     def __init__(self, bot):
         super().__init__(bot)
         self.bot = bot
-
-class Info(Cog):
-    """Commands for getting information about people and things on Discord."""
-
+        
     @command(aliases=['user', 'memberinfo', 'userinfo'])
     @guild_only()
     @bot_has_permissions(embed_links=True)
@@ -212,32 +211,6 @@ class Info(Cog):
     stats.example_usage = """
     `{prefix}stats` - get current bot/host stats
     """
-
-    @commands.hybrid_command(aliases = ['roleinfo'])
-    @guild_only()
-    @cooldown(1, 10, BucketType.channel)
-    async def role(self, ctx: DozerContext, role: discord.Role):
-        """Retrieve info about a role in this guild"""
-        embed = discord.Embed(title = f"Info for role: {role.name}", description = f"{role.mention} ({role.id})",
-                              color = role.color)
-        embed.add_field(name = "Created on", value = discord.utils.format_dt(role.created_at))
-        embed.add_field(name = "Position", value = role.position)
-        embed.add_field(name = "Color", value = str(role.color).upper())
-        embed.add_field(name = "Assigned members", value = f"{len(role.members)}", inline = False)
-        await ctx.send(embed = embed, ephemeral = True)
-
-    @commands.hybrid_command(aliases = ['withrole'])
-    @guild_only()
-    async def rolemembers(self, ctx: DozerContext, role: discord.Role):
-        """Retrieve members who have this role"""
-        await ctx.defer(ephemeral = True)
-        embeds = []
-        for page_num, page in enumerate(chunk(role.members, 10)):
-            embed = discord.Embed(title = f"Members for role: {role.name}", color = role.color)
-            embed.description = "\n".join(f"{member.mention}({member.id})" for member in page)
-            embed.set_footer(text = f"Page {page_num + 1} of {math.ceil(len(role.members) / 10)}")
-            embeds.append(embed)
-        await paginate(ctx, embeds)
 
     
 

--- a/dozer/cogs/info.py
+++ b/dozer/cogs/info.py
@@ -87,7 +87,7 @@ class Info(Cog):
             embed.add_field(name='Roles', value=', '.join(role.mention for role in roles) or 'None', inline=False)
         footers.append(f"Color: {str(member.color).upper()}")
         embed.set_footer(text="; ".join(footers))
-        await ctx.send(embed=embed, ephemeral=True)
+        await ctx.send(embed=embed)
 
     member.example_usage = """
     `{prefix}member`: show your member info
@@ -184,7 +184,7 @@ class Info(Cog):
                                                   f'{ctx.guild.premium_subscription_count} booster(s)\n'
                                                   f'{ctx.guild.filesize_limit // 1024**2}MiB files, '
                                                   f'{ctx.guild.bitrate_limit / 1000:0.1f}kbps voice')
-        await ctx.send(embed = e, ephemeral = True)
+        await ctx.send(embed = e)
 
     guild.example_usage = """
     `{prefix}guild` - get information about this guild
@@ -206,7 +206,7 @@ class Info(Cog):
                 "Process uptime": str(datetime.timedelta(seconds = round(time.time() - startup_time)))
             }.items()))
         embed = discord.Embed(title = f"Stats for {info.name}", description = f"Bot owner: {info.owner.mention}```{frame}```", color = blurple)
-        await ctx.send(embed=embed, ephemeral = True)
+        await ctx.send(embed=embed)
 
     stats.example_usage = """
     `{prefix}stats` - get current bot/host stats

--- a/dozer/cogs/info.py
+++ b/dozer/cogs/info.py
@@ -15,7 +15,21 @@ from .levels import MemberXP, GuildXPSettings
 
 blurple = discord.Color.blurple()
 datetime_format = '%Y-%m-%d %H:%M:%S\nUTC'
+startup_time = time.time()
 
+try:
+    with open("/etc/os-release") as f:
+        os_name = re.findall(r'PRETTY_NAME=\"(.+?)\"', f.read())[0]
+except Exception:
+    os_name = "Windows probably"
+
+
+class Info(Cog):
+    """Commands for getting information about people and things on Discord."""
+
+    def __init__(self, bot):
+        super().__init__(bot)
+        self.bot = bot
 
 class Info(Cog):
     """Commands for getting information about people and things on Discord."""


### PR DESCRIPTION
Added (or returned, it was in the old ftc dozer that we were using as a base for dozer2.0) Added role/rolemembers commands, that show users with role and info about specific roles Updated guild command
Updated profile/member command to be ephemeral with slash

I can also provide our version of info.py, the only thing that it currently lacks is the levels data for member profile info.