### PR TITLE
Fixes error from toa team when team does not exist

### DIFF
--- a/dozer/cogs/toa.py
+++ b/dozer/cogs/toa.py
@@ -49,6 +49,8 @@ class TOAParser:
             try:
                 async with async_timeout.timeout(5) as _, self.http.get(urljoin(self.base, endpoint),
                                                                         headers=self.headers) as response:
+                    if response.status == 404:
+                        return "[]"
                     return await response.text()
             except aiohttp.ClientError:
                 tries += 1


### PR DESCRIPTION
If the team does not exist, TOA now returns a 404 status code, this checks for that condition so a proper error message can be displayed to the user instead of a python exception.