### PR TITLE
More profile_menus updates

### DIFF
--- a/dozer/cogs/profile_menus.py
+++ b/dozer/cogs/profile_menus.py
@@ -25,20 +25,24 @@ class ProfileMenus(commands.Cog):
 
 
 class View_Profile(discord.ui.View):
+    """Creates the view for the 'View Profile' button"""
     def __init__(self):
         super().__init__()
         self.value = None
 
     @discord.ui.button(style = discord.ButtonStyle.blurple, label = "View Teams", custom_id = "onteam")
     async def onteam_button(self, button: discord.ui.Button, interaction: discord.Interaction):
+        """Creates the button that will be used to view the teams a user is on"""
         self.value = True
         self.stop()
 
 @app_commands.context_menu(name = 'View Profile')
 async def profile(interaction: discord.Interaction, member: discord.Member):
     """Creates the ephemeral response that will be sent to the user when they interact with the 'View Profile' button"""
+"""Creates the ephemeral response that will be sent to the user when they interact with the 'View Profile' button"""
     if member is None:
         member = interaction.user
+    teams = await TeamNumbers.get_by(user_id = member.id)
 
     icon_url = member.avatar.replace(static_format = 'png', size = 32) or None
 

--- a/dozer/cogs/profile_menus.py
+++ b/dozer/cogs/profile_menus.py
@@ -39,7 +39,6 @@ class View_Profile(discord.ui.View):
 @app_commands.context_menu(name = 'View Profile')
 async def profile(interaction: discord.Interaction, member: discord.Member):
     """Creates the ephemeral response that will be sent to the user when they interact with the 'View Profile' button"""
-"""Creates the ephemeral response that will be sent to the user when they interact with the 'View Profile' button"""
     if member is None:
         member = interaction.user
     teams = await TeamNumbers.get_by(user_id = member.id)

--- a/dozer/cogs/profile_menus.py
+++ b/dozer/cogs/profile_menus.py
@@ -22,13 +22,21 @@ class ProfileMenus(commands.Cog):
     async def cog_unload(self) -> None:
         self.bot.tree.remove_command(profile)
         self.bot.tree.remove_command(onteam)
-        
+
+
+class View_Profile(discord.ui.View):
+    def __init__(self):
+        super().__init__()
+        self.value = None
+
+    @discord.ui.button(style = discord.ButtonStyle.blurple, label = "View Teams", custom_id = "onteam")
+    async def onteam_button(self, button: discord.ui.Button, interaction: discord.Interaction):
+        self.value = True
+        self.stop()
 
 @app_commands.context_menu(name = 'View Profile')
 async def profile(interaction: discord.Interaction, member: discord.Member):
     """Creates the ephemeral response that will be sent to the user when they interact with the 'View Profile' button"""
-    # await interaction.response.send_message(f'{member} joined at {discord.utils.format_dt(member.joined_at)}',
-    # ephemeral = False)  # temp false for testing
     if member is None:
         member = interaction.user
 
@@ -49,8 +57,29 @@ async def profile(interaction: discord.Interaction, member: discord.Member):
     s = "s" if len(member.roles) >= 2 else ""
     embed.add_field(name = f"Role{s}: ", value = role_string, inline = False)
     embed.set_thumbnail(url = icon_url)
-    await interaction.response.send_message(embed = embed, ephemeral = True)
+    if len(teams) > 0:
+        embed.add_field(name = f"On {len(teams)} team{'s' if len(teams) > 1 else ''}",
+                        value = f"Click the button below to view the teams {member.mention} is on", inline = False)
+        view = View_Profile()
+        await interaction.response.send_message(embed = embed, view = view, ephemeral = True)
+        await view.wait()
+        if view.value:
+            msg = await interaction.original_response()
+            embed.remove_field(3 if member.premium_since is None else 4)
+            await msg.edit(embed = embed, view = None)
 
+            teams = await TeamNumbers.get_by(user_id = member.id)
+            onteam_embed = discord.Embed(color = discord.Color.blue())
+            onteam_embed.title = f'{member.display_name} is on the following team(s):'
+            onteam_embed.description = "Teams: \n"
+            for i in teams:
+                onteam_embed.description = f"{onteam_embed.description} {i.team_type.upper()} Team {i.team_number} \n"
+            if len(onteam_embed.description) > 4000:
+                onteam_embed.description = onteam_embed.description[:4000] + "..."
+
+            await interaction.followup.send(embed = onteam_embed, ephemeral = True)
+    else:
+        await interaction.response.send_message(embed = embed, ephemeral = True)
 
 @app_commands.context_menu(name = 'Teams User is On')
 async def onteam(interaction: discord.Interaction, user: discord.Member):


### PR DESCRIPTION
I completely forgot I made a bunch of changes (just over a month ago) on the dozer2 dev branch, looks to be working great. 
The "View Teams" button only shows up if the user has added themselves using the /setteam command. 
Adding a few images to show it:

![image](https://github.com/FRCDiscord/Dozer/assets/55259393/080d0387-37f0-4425-ab66-b60a6a46da8b)
![image](https://github.com/FRCDiscord/Dozer/assets/55259393/b055bf79-462e-44c4-9211-12270f929fcc)

I'm keeping the profile option ephemeral, but the regular command may possibly receive the same feature eventually as well. 
It's *slightly* different from the "Teams User is On" menu option, mainly in that it displays on the first screen if the user's on any teams and directly offers to show them, vs selecting the menu and getting either a list or a "on no teams" reponse